### PR TITLE
refactor: Update ambientService to use default model parameters for m…

### DIFF
--- a/services/voice/ambientService.js
+++ b/services/voice/ambientService.js
@@ -107,13 +107,13 @@ class AmbientService extends EventEmitter {
             const prediction = await axios.post('https://api.replicate.com/v1/predictions', {
                 version: this.config.replicate.models.musicgen.version,
                 input: {
-                    model_version: this.config.replicate.models.musicgen.ambient.model_version,
+                    model_version: this.config.replicate.models.musicgen.defaults.model_version,
                     prompt: prompt,
-                    duration: this.config.replicate.models.musicgen.ambient.duration,
-                    temperature: this.config.replicate.models.musicgen.ambient.temperature,
-                    top_k: this.config.replicate.models.musicgen.ambient.top_k,
-                    top_p: this.config.replicate.models.musicgen.ambient.top_p,
-                    classifier_free_guidance: this.config.replicate.models.musicgen.ambient.classifier_free_guidance
+                    duration: this.config.replicate.models.musicgen.defaults.duration,
+                    temperature: this.config.replicate.models.musicgen.defaults.temperature,
+                    top_k: this.config.replicate.models.musicgen.defaults.top_k,
+                    top_p: this.config.replicate.models.musicgen.defaults.top_p,
+                    classifier_free_guidance: this.config.replicate.models.musicgen.defaults.classifier_free_guidance
                 }
             }, {
                 headers: {


### PR DESCRIPTION
This pull request includes a change to the `AmbientService` class in `services/voice/ambientService.js`. The change updates the configuration for the `musicgen` model to use default values instead of specific values for the `ambient` model.

Configuration updates:

* Updated the `model_version`, `duration`, `temperature`, `top_k`, `top_p`, and `classifier_free_guidance` to use the default values from `this.config.replicate.models.musicgen.defaults` instead of `this.config.replicate.models.musicgen.ambient`.…usic generation

- Changed model_version and other parameters in ambientService to utilize defaults for improved consistency and maintainability.
- This update aligns with recent enhancements to the music generation configurations.