### PR TITLE
chore: Update Dockerfile to install SpotDL globally via pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,10 @@ RUN apt-get update && apt-get install -y \
     libgif-dev \
     librsvg2-dev \
     pkg-config \
-    # Add SpotDL and its dependencies
-    python3-spotdl \
     && rm -rf /var/lib/apt/lists/*
+
+# Install SpotDL globally with pip
+RUN pip3 install --no-cache-dir --break-system-packages spotdl
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
- Removed the commented-out installation of python3-spotdl from the Dockerfile.
- Added a command to install SpotDL globally using pip, improving the setup process.