### PR TITLE
refactor: Update Azure Speech configuration handling in voice services

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,7 +104,7 @@ jobs:
             "azure": {
               "speech": {
                 "key": "$AZURE_SPEECH_KEY",
-                "region": "eastus",
+                "region": "$AZURE_REGION",
                 "language": "en-US"
               },
               "sql": {

--- a/services/voice/index.js
+++ b/services/voice/index.js
@@ -19,8 +19,10 @@ class VoiceService extends EventEmitter {
         if (this._isInitialized) return;
 
         try {
-            // Initialize services
-            this.tts = new TTSService(this.config);
+            // Initialize TTS only if Azure Speech credentials are present
+            if (this.config.azure?.speech?.subscriptionKey && this.config.azure?.speech?.region) {
+                this.tts = new TTSService(this.config);
+            }
             
             // Initialize optional services if configured
             if (this.config.replicate?.apiKey) {
@@ -29,7 +31,10 @@ class VoiceService extends EventEmitter {
             }
             
             this._isInitialized = true;
-            console.log('Voice service initialized successfully (TTS, Music, and Ambient)');
+            console.log('Voice service initialized successfully' + 
+                (this.tts ? ' (TTS)' : '') + 
+                (this.musicService ? ' (Music)' : '') + 
+                (this.ambientService ? ' (Ambient)' : ''));
             
         } catch (error) {
             console.error('Failed to initialize voice service:', error);

--- a/services/voice/ttsService.js
+++ b/services/voice/ttsService.js
@@ -53,8 +53,18 @@ class TTSService extends EventEmitter {
         const speechKey = config.azure?.speech?.key || config.azureSpeech?.key;
         const speechRegion = config.azure?.speech?.region || config.azureSpeech?.region;
         
+        console.log('TTS Service Config:', {
+            hasAzureConfig: !!config.azure,
+            hasSpeechConfig: !!config.azure?.speech,
+            hasKey: !!speechKey,
+            hasRegion: !!speechRegion,
+            configKeys: Object.keys(config.azure?.speech || {})
+        });
+        
         if (!speechKey || !speechRegion) {
-            throw new Error('Azure Speech credentials not found in config');
+            console.log('TTS service initialized without Azure Speech credentials - TTS features will be disabled');
+            this.disabled = true;
+            return;
         }
 
         this.speechConfig = SpeechConfig.fromSubscription(
@@ -79,6 +89,11 @@ class TTSService extends EventEmitter {
     }
 
     async textToSpeech(text, voiceChannel, connection, backgroundMusicPath = null) {
+        if (this.disabled) {
+            console.log('TTS is disabled - skipping text to speech conversion');
+            return;
+        }
+
         let synthesizer = null;
         let resource = null;
         let audioStream = null;


### PR DESCRIPTION
- Changed Azure region configuration in GitHub Actions workflow to use environment variable for flexibility.
- Enhanced VoiceService initialization to only create TTSService if Azure Speech credentials are present, improving error handling.
- Added logging in TTSService to indicate whether Azure Speech credentials are available, and disabled TTS features if not, ensuring clearer service status reporting.