### PR TITLE
fix(openaiService): default to gpt-4o model for compatibility with cu…

### DIFF
--- a/services/openaiService.js
+++ b/services/openaiService.js
@@ -6,7 +6,7 @@ const config = require('../config.json');
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY || config.openaiKey;
 
 // Default model/version and sampling presets
-const DEFAULT_MODEL = 'gpt-4o-2024-05';
+const DEFAULT_MODEL = 'gpt-4o';
 
 const SAMPLING_PRESETS = {
     chat:      { temperature: 0.5, top_p: 0.9, max_tokens: 1024 },


### PR DESCRIPTION
This pull request includes a small change to the `services/openaiService.js` file. The change updates the default OpenAI model from `gpt-4o-2024-05` to `gpt-4o`.…rrent deployment