### PR TITLE
fix(tools): send generated images as Discord attachments so they rend…

### DIFF
--- a/utils/toolsRegistry.js
+++ b/utils/toolsRegistry.js
@@ -62,8 +62,19 @@ const tools = {
          * @param {{prompt:string,type?:string,style?:string}} args
          * @returns {Promise<string>} Relative path to generated image
          */
-        execute: async ({ prompt, type = 'SCENE', style = 'fantasy' }) => {
+        execute: async ({ prompt, type = 'SCENE', style = 'fantasy', interactionContext }) => {
             const imagePath = await imageDetectionHandler.generateImage(prompt, type, style);
+
+            // If we have an interaction context (original Discord interaction) send the attachment right away
+            if (interactionContext && interactionContext.channel) {
+                const { default: path } = await import('node:path');
+                await interactionContext.channel.send({
+                    files: [{ attachment: imagePath, name: path.basename(imagePath) }]
+                });
+                return '✨ I have generated and sent the image above.';
+            }
+
+            // Fallback: just return the local path (may not render in Discord)
             return imagePath;
         }
     },


### PR DESCRIPTION
…er instead of sandbox path
This pull request introduces an enhancement to the `execute` function in the `tools` object within `utils/toolsRegistry.js`. The update adds support for handling an `interactionContext` parameter, enabling immediate feedback in Discord channels when generating images.

### Key changes:

#### Enhancements to image generation and interaction:

* Updated the `execute` function to accept a new `interactionContext` parameter, which represents the original Discord interaction.
* Added logic to send the generated image directly to the Discord channel if `interactionContext.channel` is available, providing immediate feedback to users.
* Included a fallback mechanism to return the local path of the generated image if the interaction context is not provided, ensuring compatibility with non-Discord use cases.