### PR TITLE
Improve DevOps query output

### DIFF
--- a/documentation/commands.md
+++ b/documentation/commands.md
@@ -172,6 +172,16 @@ This document provides detailed information about all available commands in the 
   - `limit` (optional): Maximum number of changes to show (default: 10)
 - **Usage**: `/whatsnew days:14 limit:20`
 
+### `/devops`
+- **Description**: Interact with Azure DevOps work items
+- **Subcommands**:
+  - `connect` – link your Azure DevOps organization and project
+  - `create` – create a new work item
+  - `comment` – add a comment to a work item
+  - `query` – query work items by WIQL or ID
+  - `update` – update fields on a work item
+- **Example**: `/devops query wiql:"SELECT [System.Id] FROM WorkItems"`
+
 ## Command Flow Examples
 
 ### Starting a New Conversation

--- a/services/azureDevOpsService.js
+++ b/services/azureDevOpsService.js
@@ -70,6 +70,31 @@ class AzureDevOpsService {
         return response.data;
     }
 
+    /**
+     * Fetch multiple work items with optional specific fields
+     * @param {string} userId
+     * @param {number[]} ids
+     * @param {string[]} [fields]
+     * @returns {Promise<Array>} Array of work item objects
+     */
+    async getWorkItems(userId, ids, fields = []) {
+        const conn = this.getConnection(userId);
+        if (!conn) throw new Error('Not connected to Azure DevOps');
+        if (!ids.length) return [];
+        const idsParam = ids.join(',');
+        let url = `${conn.orgUrl}/_apis/wit/workitems?ids=${idsParam}&api-version=7.0`;
+        if (fields.length) {
+            url += `&fields=${encodeURIComponent(fields.join(','))}`;
+        }
+        const auth = Buffer.from(`:${conn.token}`).toString('base64');
+        const response = await axios.get(url, {
+            headers: {
+                'Authorization': `Basic ${auth}`
+            }
+        });
+        return response.data.value || [];
+    }
+
     async queryWIQL(userId, wiql) {
         const conn = this.getConnection(userId);
         if (!conn) throw new Error('Not connected to Azure DevOps');


### PR DESCRIPTION
## Summary
- add `getWorkItems` helper in Azure DevOps service to bulk fetch work items
- format DevOps `query` command results to show ID, type, title, and state for work items
- filter query results to the connected project
- document the `/devops` command in commands doc

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855c243917c832da3e02c706f1e8048