### PR TITLE
Add execution plan tool and search summarization

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ A feature-rich Discord chatbot designed using the Discord.js framework, featurin
 - AI-powered chat using OpenAI GPT models
 - Intelligent web search using Perplexity AI with enhanced formatting
   - Proper markdown conversion for search results
+  - Automatic aggregation of search results into final answers
   - Smart message chunking for long responses
   - Enhanced readability with proper Discord styling
   - Clickable links and proper code block formatting

--- a/documentation/gemini_tool_integration.md
+++ b/documentation/gemini_tool_integration.md
@@ -42,6 +42,14 @@ Parameters:
   - prompt: string (Detailed description of what to generate.)
   - type: string (Image category)
   - style: string (Artistic style to apply (e.g. fantasy, realistic, anime))
+ 
+**echoMessage**: Echo back the provided text.
+Parameters:
+  - text: string (Text to echo)
+
+**executePlan**: Execute multiple tools sequentially and return combined results.
+Parameters:
+  - plan: array of { name: string, args: object }
 
 If you don't need to use any tools, respond normally with text.
 ```
@@ -111,6 +119,8 @@ All tools from the `toolsRegistry.js` are available:
 - **playTrack**: Music playback and playlist management
 - **setNickname**: Bot and user nickname management
 - **speakMessage**: Text-to-speech conversion
+- **echoMessage**: Returns the provided text
+- **executePlan**: Runs multiple tools sequentially and aggregates results
 
 ## Provider Capabilities
 

--- a/tests/testExecutionPlan.js
+++ b/tests/testExecutionPlan.js
@@ -1,0 +1,26 @@
+const toolsRegistry = require('../utils/toolsRegistry');
+
+async function runTest() {
+    console.log('\n=== TESTING EXECUTION PLAN ===\n');
+    const plan = [
+        { name: 'echoMessage', args: { text: 'first' } },
+        { name: 'echoMessage', args: { text: 'second' } }
+    ];
+
+    try {
+        const result = await toolsRegistry.execute('executePlan', { plan });
+        if (result.includes('first') && result.includes('second')) {
+            console.log('TEST PASSED');
+            return true;
+        }
+        console.log('TEST FAILED');
+        return false;
+    } catch (err) {
+        console.error('Error:', err.message);
+        return false;
+    }
+}
+
+if (require.main === module) {
+    runTest().then(success => process.exit(success ? 0 : 1));
+}

--- a/utils/aiSearchHandler.js
+++ b/utils/aiSearchHandler.js
@@ -98,28 +98,18 @@ class AISearchHandler {
                 console.log(`Auto-executing search without approval: "${query}"`);
                 const searchResult = await perplexityService.search(query);
                 const formattedResult = formatSearchResults(searchResult);
-                
+
                 // Store the result
                 this.searchResults.set(requestId, {
                     result: formattedResult,
                     timestamp: Date.now()
                 });
 
-                // Send the results in chunks
-                const chunks = chunkMessage(formattedResult);
-                for (const [index, chunk] of chunks.entries()) {
-                    if (index === 0) {
-                        await interaction.channel.send(`🔍 **Search Results:**\n\n${chunk}`);
-                    } else {
-                        await interaction.channel.send(chunk);
-                    }
-                }
-
                 // Clean up
                 this.pendingRequests.delete(requestId);
-                
-                // Return null to indicate no approval is needed
-                return null;
+
+                // Return result for further processing
+                return { requestId: null, result: formattedResult };
             } catch (error) {
                 console.error('Auto-search execution error:', error);
                 this.pendingRequests.delete(requestId);
@@ -154,22 +144,12 @@ class AISearchHandler {
 
             const searchResult = await perplexityService.search(request.query);
             const formattedResult = formatSearchResults(searchResult);
-            
+
             // Store the result
             this.searchResults.set(requestId, {
                 result: formattedResult,
                 timestamp: Date.now()
             });
-
-            // Send the results in chunks
-            const chunks = chunkMessage(formattedResult);
-            for (const [index, chunk] of chunks.entries()) {
-                if (index === 0) {
-                    await interaction.channel.send(`🔍 **Search Results:**\n\n${chunk}`);
-                } else {
-                    await interaction.channel.send(chunk);
-                }
-            }
 
             // Clean up
             this.pendingRequests.delete(requestId);


### PR DESCRIPTION
## Summary
- add `executePlan` and `echoMessage` tools
- update Gemini tool documentation with new tools
- aggregate search results before responding
- update search command and chat handler logic
- document automatic search aggregation in README
- test execution plan helper

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855cc3a262c832db3f3eb39dc7382f0