### PR TITLE
Add rotating idle status messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,20 @@ const { getConnection, closeConnection } = require('./azureDb');
 const { parseTrackName } = require('./utils/musicUtils');
 const aiService = require('./services/aiService');
 
+// Fun idle status messages when no music is playing
+const idleStatusMessages = [
+    'Pondering the orb',
+    'Listening to the voices in my head',
+    "Moderating a debate between the server's dust bunnies",
+    'Staring into the void',
+    'Dreaming of electric sheep',
+    'Trying to remember a punchline'
+];
+
+// Interval to rotate idle status (10 minutes)
+const IDLE_STATUS_INTERVAL_MS = 10 * 60 * 1000;
+let idleStatusInterval = null;
+
 // Add near the top, after the requires
 const DEBUG_MODE = process.argv.includes('--debug');
 
@@ -245,27 +259,51 @@ async function updateGlobalPresence(client) {
 		}
 	}
 
-	if (latestGuild && latestGuild.track) {
-		const trackInfo = parseTrackName(latestGuild.track.name);
-		await client.user.setPresence({
-			activities: [{
-				name: `${trackInfo.artist} - ${trackInfo.title}`,
-				type: 2 // LISTENING
-			}],
-			status: 'online'
-		});
-		logger.info(`Global presence updated: Listening to ${trackInfo.title}`);
-	} else {
-		// No guilds playing music, set default presence
-		await client.user.setPresence({
-			activities: [{
-				name: 'your voice',
-				type: 2 // LISTENING
-			}],
-			status: 'online'
-		});
-		logger.info('Global presence reset to default (no music playing).');
-	}
+        if (latestGuild && latestGuild.track) {
+                const trackInfo = parseTrackName(latestGuild.track.name);
+                // Stop rotating idle status while music is playing
+                if (idleStatusInterval) {
+                        clearInterval(idleStatusInterval);
+                        idleStatusInterval = null;
+                }
+                await client.user.setPresence({
+                        activities: [{
+                                name: `${trackInfo.artist} - ${trackInfo.title}`,
+                                type: 2 // LISTENING
+                        }],
+                        status: 'online'
+                });
+                logger.info(`Global presence updated: Listening to ${trackInfo.title}`);
+        } else {
+                // No guilds playing music, set a fun idle status
+                const message = idleStatusMessages[Math.floor(Math.random() * idleStatusMessages.length)];
+                await client.user.setPresence({
+                        activities: [{
+                                name: message,
+                                type: 2 // LISTENING
+                        }],
+                        status: 'online'
+                });
+                logger.info('Global presence reset to idle state.');
+
+                // Start rotating idle status if not already running
+                if (!idleStatusInterval) {
+                        idleStatusInterval = setInterval(async () => {
+                                try {
+                                        if (activeMusicGuilds.size === 0) {
+                                                const msg = idleStatusMessages[Math.floor(Math.random() * idleStatusMessages.length)];
+                                                await client.user.setPresence({
+                                                        activities: [{ name: msg, type: 2 }],
+                                                        status: 'online'
+                                                });
+                                                logger.info(`Idle presence rotated to: ${msg}`);
+                                        }
+                                } catch (err) {
+                                        logger.error('Error rotating idle presence:', err);
+                                }
+                        }, IDLE_STATUS_INTERVAL_MS);
+                }
+        }
 }
 
 client.once(Events.ClientReady, async readyClient => {
@@ -338,21 +376,27 @@ client.once(Events.ClientReady, async readyClient => {
 	updateGlobalPresence(readyClient);
 
 	// Ensure proper cleanup on shutdown
-	process.on('SIGINT', () => {
-		logger.info('Received SIGINT signal, cleaning up resources...');
-		if (client.musicService) {
-			client.musicService.dispose();
-		}
-		process.exit(0);
-	});
+        process.on('SIGINT', () => {
+                logger.info('Received SIGINT signal, cleaning up resources...');
+                if (client.musicService) {
+                        client.musicService.dispose();
+                }
+                if (idleStatusInterval) {
+                        clearInterval(idleStatusInterval);
+                }
+                process.exit(0);
+        });
 
-	process.on('SIGTERM', () => {
-		logger.info('Received SIGTERM signal, cleaning up resources...');
-		if (client.musicService) {
-			client.musicService.dispose();
-		}
-		process.exit(0);
-	});
+        process.on('SIGTERM', () => {
+                logger.info('Received SIGTERM signal, cleaning up resources...');
+                if (client.musicService) {
+                        client.musicService.dispose();
+                }
+                if (idleStatusInterval) {
+                        clearInterval(idleStatusInterval);
+                }
+                process.exit(0);
+        });
 });
 
 client.on(Events.InteractionCreate, async interaction => {
@@ -596,18 +640,22 @@ client.ws.on('close', (event) => {
 
 // Graceful shutdown handling
 const shutdown = async () => {
-	logger.info('Shutting down...');
-	try {
-		if (client.musicService) {
-			logger.debug('Cleaning up music service...');
-			client.musicService.dispose();
-			logger.debug('Music service cleanup complete');
-		}
-		if (client.automationService) {
-			logger.debug('Stopping automation service...');
-			client.automationService.stop();
-			logger.debug('Automation service stopped');
-		}
+        logger.info('Shutting down...');
+        try {
+                if (client.musicService) {
+                        logger.debug('Cleaning up music service...');
+                        client.musicService.dispose();
+                        logger.debug('Music service cleanup complete');
+                }
+                if (client.automationService) {
+                        logger.debug('Stopping automation service...');
+                        client.automationService.stop();
+                        logger.debug('Automation service stopped');
+                }
+
+                if (idleStatusInterval) {
+                        clearInterval(idleStatusInterval);
+                }
 		
 		// Close database connection
 		logger.debug('Closing database connection...');


### PR DESCRIPTION
## Summary
- add idle status messages list and interval constants
- rotate idle listening messages when no music is playing
- stop rotation when music starts and on shutdown

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_68560c0c3cc8832d9dc417a53664d5a8