### PR TITLE
Set up Cursor Cloud dev environment (AGENTS.md + update script)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,51 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Goobster is a **single service**: a self-hostable Node.js Discord bot (`index.js`) using discord.js,
+a local SQLite database (`better-sqlite3`), system FFmpeg, and pluggable AI providers
+(OpenAI / Gemini / local Ollama). All cloud integrations are optional and degrade gracefully.
+
+Standard commands live in `package.json` and `README.md`; prefer those. Key ones:
+- Dev run: `npm run dev` (nodemon `index.js`) — does NOT call `deploy-commands`.
+- Prod-style run: `npm start` (runs `deploy-commands.js` then `index.js`).
+- DB init: `npm run db-init` (creates `data/goobster.sqlite`; `db/schema.sql` is also applied automatically on every DB open).
+- Tests: `npm test` / `npm run test:integration`. Lint: `npm run lint`.
+
+### Non-obvious caveats (discovered during setup)
+
+- **`config.json` is required and gitignored.** `index.js` and `deploy-commands.js` read Discord
+  credentials (`token`, `clientId`, `guildIds`) from `config.json` **only** — NOT from env vars.
+  The VM starts without it, so create it before running the bot. AI/integration keys
+  (`OPENAI_API_KEY`, `GEMINI_API_KEY`, `PERPLEXITY_API_KEY`, `ELEVENLABS_API_KEY`) ARE read from
+  env by `config/aiConfig.js` / root `config.js`, so those can come from injected secrets.
+  Build `config.json` from secrets before starting, e.g.:
+  ```bash
+  [ -f config.json ] || cat > config.json <<JSON
+  {
+    "clientId": "${DISCORD_CLIENT_ID}",
+    "guildIds": [${DISCORD_GUILD_IDS:-\"\"}],
+    "token": "${DISCORD_BOT_TOKEN}",
+    "DEFAULT_PROMPT": "You are Goobster, a quirky and clever Discord bot.",
+    "ai": { "provider": "" }
+  }
+  JSON
+  ```
+  (`ai.provider` empty = auto-detect: OpenAI if `OPENAI_API_KEY` set, else Gemini, else Ollama.)
+
+- **`npm run lint` currently fails: no ESLint config exists** in the repo (ESLint 8 needs
+  `.eslintrc*`). This is a pre-existing repo gap, not an environment issue.
+
+- **`npm test` exits 1 with "No tests found"** — there are no Jest test files yet (the `tests/`
+  folder holds standalone manual scripts, not Jest specs). Use `jest --passWithNoTests` if a
+  zero-exit is needed.
+
+- **Local Ollama inference (`ollama serve`) segfaults in this VM** (`llama-server ... segmentation
+  fault`), across multiple small models and with flash-attention disabled. The AI *routing* layer
+  (`services/aiService.js` → `ollamaService.js`) works, but local generation does not complete here.
+  For an end-to-end chat demo, use a cloud provider key (`OPENAI_API_KEY` or `GEMINI_API_KEY`)
+  rather than the local Ollama fallback.
+
+- The bot exposes an Express health endpoint at `http://localhost:3000/health`. On invalid Discord
+  token, `index.js` logs in, fails with `TokenInvalid`, and calls `process.exit(1)` — a real bot
+  token is required to stay connected.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,19 +19,28 @@ Standard commands live in `package.json` and `README.md`; prefer those. Key ones
   The VM starts without it, so create it before running the bot. AI/integration keys
   (`OPENAI_API_KEY`, `GEMINI_API_KEY`, `PERPLEXITY_API_KEY`, `ELEVENLABS_API_KEY`) ARE read from
   env by `config/aiConfig.js` / root `config.js`, so those can come from injected secrets.
-  Build `config.json` from secrets before starting, e.g.:
+  Build `config.json` from secrets before starting (guild id may be a bare id or a JSON array;
+  snowflakes must be quoted strings):
   ```bash
-  [ -f config.json ] || cat > config.json <<JSON
+  if [ ! -f config.json ]; then
+    case "$DISCORD_GUILD_IDS" in
+      \[*) GID_JSON="$DISCORD_GUILD_IDS" ;;   # already a JSON array
+      *)   GID_JSON="[\"$DISCORD_GUILD_IDS\"]" ;;
+    esac
+    cat > config.json <<JSON
   {
     "clientId": "${DISCORD_CLIENT_ID}",
-    "guildIds": [${DISCORD_GUILD_IDS:-\"\"}],
+    "guildIds": ${GID_JSON},
     "token": "${DISCORD_BOT_TOKEN}",
     "DEFAULT_PROMPT": "You are Goobster, a quirky and clever Discord bot.",
     "ai": { "provider": "" }
   }
   JSON
+  fi
   ```
   (`ai.provider` empty = auto-detect: OpenAI if `OPENAI_API_KEY` set, else Gemini, else Ollama.)
+  Then `npm run deploy-commands` registers slash commands to the guild, and `npm run dev`
+  (or `node index.js`) starts the bot. A successful connect logs `Ready! Logged in as <tag>`.
 
 - **`npm run lint` currently fails: no ESLint config exists** in the repo (ESLint 8 needs
   `.eslintrc*`). This is a pre-existing repo gap, not an environment issue.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for Goobster (self-hostable Discord bot) on Cursor Cloud and documents non-obvious startup caveats for future agents.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section (single Node.js service, standard commands reference, `config.json`-from-secrets snippet, and caveats found during setup).
- Update script (configured separately, not in-repo): `npm install`.

No application code was modified.

## Environment verified

- Node v22.14.0, npm 10.9.7, FFmpeg 6.1.1 present.
- `npm install` — 776 packages, native modules built (`better-sqlite3`, `sharp`, `sodium-native`, `@discordjs/opus`).
- `npm run db-init` — created `data/goobster.sqlite` with 15 tables.
- `npm run deploy-commands` — registered 44 slash commands to the test guild.
- `node index.js` — connected to Discord: `Ready! Logged in as Goobster#5976`; `/health` returns healthy; voice/automation/heartbeat/memory/music services initialized.

## End-to-end "hello world" (core functionality)

The bot generated an AI reply through the real service layer (OpenAI `gpt-5.4-mini`) and posted it into `#general`:

[discord_hello_world.log](https://cursor.com/agents/bc-46256ebd-36f1-4ef5-a523-3a6b64f282fe/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdiscord_hello_world.log)

## Known caveats (documented in AGENTS.md)

- `config.json` is required and gitignored; Discord creds are read from it, not env.
- `npm run lint` fails — repo has no ESLint config (pre-existing).
- `npm test` exits 1 — no Jest specs exist yet (`--passWithNoTests` for zero exit).
- Local Ollama inference segfaults in this VM; use a cloud AI key for chat generation.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-46256ebd-36f1-4ef5-a523-3a6b64f282fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46256ebd-36f1-4ef5-a523-3a6b64f282fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

