### PR TITLE
Add /recall and privacy commands (Tier 1 "Now" phase of differentiation strategy)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,9 +45,10 @@ Standard commands live in `package.json` and `README.md`; prefer those. Key ones
 - **`npm run lint` currently fails: no ESLint config exists** in the repo (ESLint 8 needs
   `.eslintrc*`). This is a pre-existing repo gap, not an environment issue.
 
-- **`npm test` exits 1 with "No tests found"** — there are no Jest test files yet (the `tests/`
-  folder holds standalone manual scripts, not Jest specs). Use `jest --passWithNoTests` if a
-  zero-exit is needed.
+- **`npm test` runs the Jest specs in `tests/*.test.js`** (e.g. `privacyService.test.js`,
+ `memoryPrivacy.test.js`) and must pass. They use a throwaway SQLite file via `GOOBSTER_DB_PATH`,
+ so no config or network is needed. The other `tests/test*.js` files are standalone manual
+ scripts, not Jest specs.
 
 - **Local Ollama inference (`ollama serve`) segfaults in this VM** (`llama-server ... segmentation
   fault`), across multiple small models and with flash-attention disabled. The AI *routing* layer

--- a/README.md
+++ b/README.md
@@ -27,9 +27,16 @@ A feature-rich, **self-hostable** Discord chatbot built on Discord.js, featuring
 - Automatic fallback to Ollama when no OpenAI key is configured
 - Intelligent web search using Perplexity AI (optional) with enhanced formatting
 - Multi-turn dialogue support with conversation memory (local SQLite)
+- **Long-term semantic memory**: `/recall` lets anyone ask the server's memory anything, answered from locally stored embeddings with sources
 - Customizable chat prompts, per-guild personality directives, meme mode
 - Configurable thread preferences (use threads or respond in channel)
 - Message reactions: regenerate, pin, branch, deep dive, summarize
+
+### Privacy (provable, not just promised)
+- `/what-do-you-know-about-me` — full transparency report of everything stored about you
+- `/forget-me` — one-command, bot-wide erasure of your data (memories, facts, history, follow-ups, preferences), including a scan for name-mentions in server facts and summaries, with a post-erasure audit
+- `/privacy` — admin retention windows (auto-expire old memories) and per-channel memory exclusions
+- Everything lives in a local SQLite file on hardware you own — no third-party storage
 
 ### Audio System
 - Music downloads via SpotDL/yt-dlp to local storage

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026-07-06
+
+### Added
+- `/recall` — ask the server's long-term memory anything; answers are grounded in locally stored memories with source snippets, filtered by channel visibility
+- `/what-do-you-know-about-me` — private transparency report of all stored data about you
+- `/forget-me` — button-confirmed, bot-wide erasure of all your data (memories, facts, follow-ups, chat history, nicknames, preferences), with name-mention review of server facts/summaries/follow-up notes, usage anonymization, and a post-erasure audit
+- `/privacy` — admin memory retention windows (nightly auto-purge) and per-channel memory exclusions
+- Command usage counters (`command_log`) feeding baseline metrics; `/usage` now shows `/recall` adoption
+- First real Jest specs (`tests/privacyService.test.js`, `tests/memoryPrivacy.test.js`) — `npm test` now passes
+
 ## 2025-02-25
 
 ### Added

--- a/commands/chat/recall.js
+++ b/commands/chat/recall.js
@@ -1,0 +1,115 @@
+const { SlashCommandBuilder, EmbedBuilder, PermissionFlagsBits } = require('discord.js');
+const memoryService = require('../../services/memoryService');
+const factsService = require('../../services/factsService');
+const aiService = require('../../services/aiService');
+const usageTracker = require('../../services/usageTracker');
+
+// Pull more candidates than the chat-context default: answering a direct
+// question benefits from a wider net than prompt enrichment does.
+const RECALL_LIMIT = 8;
+const MAX_SOURCES_SHOWN = 4;
+
+/**
+ * Drop memories the asking user could not have seen themselves: anything from
+ * a channel that still exists but is not visible to them. Memories without a
+ * channel (or from since-deleted channels) are kept.
+ */
+function filterByChannelVisibility(memories, interaction) {
+    if (!interaction.guild || !interaction.member) return memories;
+
+    return memories.filter(memory => {
+        if (!memory.channelId) return true;
+        const channel = interaction.guild.channels.cache.get(memory.channelId);
+        if (!channel) return true;
+        return channel.permissionsFor(interaction.member)?.has(PermissionFlagsBits.ViewChannel) ?? false;
+    });
+}
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('recall')
+        .setDescription('Ask the server\'s long-term memory anything.')
+        .addStringOption(option =>
+            option.setName('question')
+                .setDescription('What do you want to know? e.g. "what did we decide about the minecraft server?"')
+                .setRequired(true)
+                .setMaxLength(400)),
+
+    async execute(interaction) {
+        if (!interaction.guildId) {
+            await interaction.reply({ content: 'Server memory only exists inside servers.', ephemeral: true });
+            return;
+        }
+
+        await interaction.deferReply();
+        const question = interaction.options.getString('question');
+
+        usageTracker.logCommand({
+            command: 'recall',
+            guildId: interaction.guildId,
+            userId: interaction.user.id
+        });
+
+        try {
+            const recalled = await memoryService.recall({
+                guildId: interaction.guildId,
+                query: question,
+                limit: RECALL_LIMIT
+            });
+            const memories = filterByChannelVisibility(recalled, interaction);
+
+            if (memories.length === 0) {
+                await interaction.editReply(
+                    `I dug through my memory but found nothing about that. ` +
+                    `I only remember conversations that happened while I was around!`
+                );
+                return;
+            }
+
+            const memoryLines = memories.map(m => {
+                const when = m.createdAt ? m.createdAt.split(' ')[0] : 'unknown date';
+                return `- [${when}] ${m.authorName || 'someone'}: ${m.content}`;
+            });
+            const guildFacts = factsService.getGuildFacts(interaction.guildId);
+
+            const answer = await aiService.chatText([
+                {
+                    role: 'system',
+                    content: `You are Goobster, a Discord bot answering a question from the server's long-term memory. Answer ONLY from the memory excerpts (and server facts) below - never invent details. If they don't fully answer the question, say what you do remember and be upfront about the gaps. Mention who said things and roughly when, when that helps. Keep it under 150 words, with your usual light personality.
+
+MEMORY EXCERPTS (retrieved by similarity, newest context wins on conflicts):
+${memoryLines.join('\n')}
+${guildFacts.length > 0 ? `\nKNOWN SERVER FACTS:\n${guildFacts.map(f => `- ${f.content}`).join('\n')}` : ''}`
+                },
+                { role: 'user', content: question }
+            ], {
+                preset: 'chat',
+                max_tokens: 400,
+                usageContext: { guildId: interaction.guildId, userId: interaction.user.id }
+            });
+
+            const sources = memories.slice(0, MAX_SOURCES_SHOWN).map(m => {
+                const when = m.createdAt ? m.createdAt.split(' ')[0] : '?';
+                const snippet = m.content.length > 90 ? `${m.content.slice(0, 90)}…` : m.content;
+                return `- \`${when}\` **${m.authorName || 'someone'}** (${(m.similarity * 100).toFixed(0)}%): ${snippet}`;
+            });
+
+            const embed = new EmbedBuilder()
+                .setColor('#9B59B6')
+                .setTitle(`🧠 ${question.length > 240 ? question.slice(0, 240) + '…' : question}`)
+                .setDescription(answer.slice(0, 4000))
+                .addFields({
+                    name: `From ${memories.length} ${memories.length === 1 ? 'memory' : 'memories'}`,
+                    value: sources.join('\n').slice(0, 1024),
+                    inline: false
+                })
+                .setFooter({ text: 'Long-term memory is stored locally on this server\'s own database.' })
+                .setTimestamp();
+
+            await interaction.editReply({ embeds: [embed] });
+        } catch (error) {
+            console.error('Recall command failed:', error);
+            await interaction.editReply(`❌ My memory glitched out: ${error.message}`);
+        }
+    }
+};

--- a/commands/settings/privacy.js
+++ b/commands/settings/privacy.js
@@ -1,0 +1,102 @@
+const { SlashCommandBuilder, PermissionFlagsBits, ChannelType } = require('discord.js');
+const memoryService = require('../../services/memoryService');
+const { getMemoryRetentionDays, setMemoryRetentionDays } = require('../../utils/guildSettings');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('privacy')
+        .setDescription('Control what Goobster remembers in this server.')
+        .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild)
+        .addSubcommand(subcommand =>
+            subcommand
+                .setName('status')
+                .setDescription('Show retention and memory scope settings'))
+        .addSubcommand(subcommand =>
+            subcommand
+                .setName('retention')
+                .setDescription('Auto-delete long-term memories older than N days')
+                .addIntegerOption(option =>
+                    option.setName('days')
+                        .setDescription('Days to keep memories (0 = keep forever)')
+                        .setRequired(true)
+                        .setMinValue(0)
+                        .setMaxValue(3650)))
+        .addSubcommand(subcommand =>
+            subcommand
+                .setName('exclude')
+                .setDescription('Stop remembering a channel (and forget what\'s already stored from it)')
+                .addChannelOption(option =>
+                    option.setName('channel')
+                        .setDescription('Channel Goobster must not remember')
+                        .addChannelTypes(ChannelType.GuildText)
+                        .setRequired(true)))
+        .addSubcommand(subcommand =>
+            subcommand
+                .setName('include')
+                .setDescription('Resume remembering a previously excluded channel')
+                .addChannelOption(option =>
+                    option.setName('channel')
+                        .setDescription('Channel to remember again')
+                        .addChannelTypes(ChannelType.GuildText)
+                        .setRequired(true))),
+
+    async execute(interaction) {
+        if (!interaction.guildId) {
+            await interaction.reply({ content: 'Privacy settings are per-server.', ephemeral: true });
+            return;
+        }
+
+        const subcommand = interaction.options.getSubcommand();
+        const guildId = interaction.guildId;
+
+        if (subcommand === 'status') {
+            const retention = await getMemoryRetentionDays(guildId);
+            const excluded = memoryService.getExcludedChannels(guildId);
+            const stats = memoryService.getStats(guildId);
+
+            await interaction.reply({
+                content: [
+                    '🔒 **Privacy settings for this server**',
+                    '',
+                    `**Memory retention:** ${retention ? `${retention} days (older memories auto-delete nightly)` : 'keep forever'}`,
+                    `**Excluded channels:** ${excluded.length > 0 ? excluded.map(id => `<#${id}>`).join(', ') : 'none - all channels are remembered'}`,
+                    `**Stored memories:** ${stats.count}`,
+                    '',
+                    '*Anyone can run `/what-do-you-know-about-me` and `/forget-me` for their own data.*'
+                ].join('\n'),
+                ephemeral: true
+            });
+        } else if (subcommand === 'retention') {
+            const days = interaction.options.getInteger('days');
+            const stored = await setMemoryRetentionDays(guildId, days);
+
+            if (stored) {
+                const purged = memoryService.applyRetention(guildId);
+                await interaction.reply({
+                    content: `🕐 Memories now expire after **${stored} days**.` +
+                        (purged > 0 ? ` ${purged} existing ${purged === 1 ? 'memory' : 'memories'} past that window ${purged === 1 ? 'was' : 'were'} deleted now.` : ''),
+                    ephemeral: true
+                });
+            } else {
+                await interaction.reply({ content: '♾️ Memories are now kept forever (no retention window).', ephemeral: true });
+            }
+        } else if (subcommand === 'exclude') {
+            const channel = interaction.options.getChannel('channel');
+            const removed = memoryService.excludeChannel(guildId, channel.id);
+            await interaction.reply({
+                content: `🙈 I won't remember anything from <#${channel.id}> anymore.` +
+                    (removed > 0 ? ` Also deleted ${removed} ${removed === 1 ? 'memory' : 'memories'} already stored from it.` : ''),
+                ephemeral: true
+            });
+        } else if (subcommand === 'include') {
+            const channel = interaction.options.getChannel('channel');
+            const changed = memoryService.includeChannel(guildId, channel.id);
+            await interaction.reply({
+                content: changed > 0
+                    ? `👀 I'll start remembering <#${channel.id}> again (from now on - past messages stay forgotten).`
+                    : `<#${channel.id}> wasn't excluded, so nothing changed.`,
+                ephemeral: true
+            });
+        }
+    }
+};

--- a/commands/utility/forgetMe.js
+++ b/commands/utility/forgetMe.js
@@ -1,0 +1,108 @@
+const { SlashCommandBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, ComponentType } = require('discord.js');
+const privacyService = require('../../services/privacyService');
+const usageTracker = require('../../services/usageTracker');
+
+const CONFIRM_TIMEOUT_MS = 60 * 1000;
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('forget-me')
+        .setDescription('Erase everything Goobster knows about you, bot-wide. Cannot be undone.'),
+
+    async execute(interaction) {
+        if (!interaction.guildId) {
+            await interaction.reply({ content: 'Run this inside a server.', ephemeral: true });
+            return;
+        }
+
+        const confirmRow = new ActionRowBuilder().addComponents(
+            new ButtonBuilder()
+                .setCustomId('forgetme_confirm')
+                .setLabel('Yes, erase everything')
+                .setStyle(ButtonStyle.Danger),
+            new ButtonBuilder()
+                .setCustomId('forgetme_cancel')
+                .setLabel('Cancel')
+                .setStyle(ButtonStyle.Secondary)
+        );
+
+        const reply = await interaction.reply({
+            content:
+                '⚠️ **This will permanently erase everything I know about you, across the whole bot** - ' +
+                'memories, facts, follow-ups, chat history, nicknames, and preferences. ' +
+                'Usage rows are kept for cost accounting but anonymized (your ID is removed). ' +
+                'Server facts and conversation summaries that mention you by name are scanned and deleted too.\n\n' +
+                'This cannot be undone. Are you sure?',
+            components: [confirmRow],
+            ephemeral: true,
+            fetchReply: true
+        });
+
+        let confirmation;
+        try {
+            confirmation = await reply.awaitMessageComponent({
+                componentType: ComponentType.Button,
+                filter: i => i.user.id === interaction.user.id,
+                time: CONFIRM_TIMEOUT_MS
+            });
+        } catch {
+            await interaction.editReply({ content: 'Timed out - nothing was deleted.', components: [] });
+            return;
+        }
+
+        if (confirmation.customId === 'forgetme_cancel') {
+            await confirmation.update({ content: 'Cancelled - nothing was deleted.', components: [] });
+            return;
+        }
+
+        await confirmation.update({ content: '🗑️ Erasing everything I know about you…', components: [] });
+
+        // Log before erasure; the erasure itself anonymizes this row
+        usageTracker.logCommand({
+            command: 'forget-me',
+            guildId: interaction.guildId,
+            userId: interaction.user.id
+        });
+
+        try {
+            const extraNames = [
+                interaction.user.username,
+                interaction.user.globalName,
+                interaction.member?.displayName
+            ].filter(Boolean);
+
+            const counts = privacyService.forgetUser({
+                userId: interaction.user.id,
+                extraNames
+            });
+            const audit = privacyService.auditUser({ userId: interaction.user.id });
+
+            const lines = [
+                '✅ **Done. Here\'s exactly what was erased:**',
+                '',
+                `- Memories written by you: **${counts.memories}**`,
+                `- Facts about you: **${counts.userFacts}**`,
+                `- Server facts mentioning your name: **${counts.reviewedGuildFacts}**`,
+                `- Conversation summaries mentioning your name: **${counts.reviewedSummaries}**`,
+                `- Follow-ups by/about you: **${counts.followups}**`,
+                `- Chat history: **${counts.messages}** messages, **${counts.conversations}** conversations, **${counts.prompts}** prompts`,
+                `- Nicknames: **${counts.nicknames}**, preferences: **${counts.preferences}**, profile: **${counts.profile}**`,
+                `- Usage rows anonymized (kept for cost accounting): **${counts.anonymizedUsageRows}**`,
+                '',
+                audit.total === 0
+                    ? '🔎 Post-erasure audit: **zero rows** still attributed to you.'
+                    : `⚠️ Post-erasure audit found ${audit.total} leftover rows - please report this as a bug.`,
+                '',
+                '*I\'ll naturally learn about you again if you keep chatting with me. If you want me to never remember a channel, an admin can use `/privacy exclude`.*'
+            ];
+
+            await interaction.editReply({ content: lines.join('\n'), components: [] });
+        } catch (error) {
+            console.error('Forget-me failed:', error);
+            await interaction.editReply({
+                content: `❌ Erasure failed and was rolled back - nothing was partially deleted: ${error.message}`,
+                components: []
+            });
+        }
+    }
+};

--- a/commands/utility/help.js
+++ b/commands/utility/help.js
@@ -95,6 +95,11 @@ async function sendCategoryHelp(interaction, category) {
                     inline: true 
                 },
                 { 
+                    name: '/recall', 
+                    value: '• Ask the server\'s long-term memory anything\n• Usage: `/recall question:"what did we decide about the minecraft server?"`', 
+                    inline: true 
+                },
+                { 
                     name: '/joke', 
                     value: '• Get an AI-generated joke\n• Usage: `/joke category:dad`', 
                     inline: true 
@@ -215,6 +220,21 @@ async function sendCategoryHelp(interaction, category) {
                 { 
                     name: '/resetchatdata', 
                     value: '• Delete all your chat data\n• ⚠️ Cannot be undone\n• Usage: `/resetchatdata`', 
+                    inline: true 
+                },
+                { 
+                    name: '/what-do-you-know-about-me', 
+                    value: '• Private report of everything Goobster stored about you\n• Usage: `/what-do-you-know-about-me`', 
+                    inline: true 
+                },
+                { 
+                    name: '/forget-me', 
+                    value: '• Erase everything Goobster knows about you\n• ⚠️ Bot-wide, cannot be undone\n• Usage: `/forget-me`', 
+                    inline: true 
+                },
+                { 
+                    name: '/privacy', 
+                    value: '• Admin: memory retention + channel exclusions\n• Usage: `/privacy retention days:90`', 
                     inline: true 
                 },
                 { 

--- a/commands/utility/usage.js
+++ b/commands/utility/usage.js
@@ -61,6 +61,16 @@ module.exports = {
             });
         }
 
+        // Baseline metric from the differentiation strategy: /recall usage
+        const recallStats = usageTracker.getCommandStats({ command: 'recall', guildId: interaction.guildId, days });
+        embed.addFields({
+            name: 'Memory recall',
+            value: recallStats.calls > 0
+                ? `\`/recall\`: ${recallStats.calls} uses by ${recallStats.uniqueUsers} ${recallStats.uniqueUsers === 1 ? 'user' : 'users'}`
+                : '`/recall` not used in this window.',
+            inline: false
+        });
+
         embed.setFooter({ text: 'Note: heartbeat, consolidation, and memory calls without a user are included in totals.' });
 
         await interaction.reply({ embeds: [embed], ephemeral: true });

--- a/commands/utility/whatDoYouKnowAboutMe.js
+++ b/commands/utility/whatDoYouKnowAboutMe.js
@@ -1,0 +1,82 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const privacyService = require('../../services/privacyService');
+const usageTracker = require('../../services/usageTracker');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('what-do-you-know-about-me')
+        .setDescription('See everything Goobster has stored about you (private reply).'),
+
+    async execute(interaction) {
+        if (!interaction.guildId) {
+            await interaction.reply({ content: 'This report is per-server - run it inside a server.', ephemeral: true });
+            return;
+        }
+
+        await interaction.deferReply({ ephemeral: true });
+
+        usageTracker.logCommand({
+            command: 'what-do-you-know-about-me',
+            guildId: interaction.guildId,
+            userId: interaction.user.id
+        });
+
+        try {
+            const report = privacyService.buildUserReport({
+                guildId: interaction.guildId,
+                userId: interaction.user.id
+            });
+
+            const embed = new EmbedBuilder()
+                .setColor('#43B581')
+                .setTitle('🔍 What I know about you')
+                .setDescription(
+                    'Everything below lives in a local SQLite database on the machine running me - ' +
+                    'no third-party storage. Use `/forget-me` to erase all of it.'
+                )
+                .setTimestamp();
+
+            if (report.facts.length > 0) {
+                const factLines = report.facts.map(f => `- ${f.content} *(${f.source})*`);
+                let block = '';
+                for (const line of factLines) {
+                    if (block.length + line.length + 1 > 1024) break;
+                    block += (block ? '\n' : '') + line;
+                }
+                embed.addFields({ name: `Facts about you in this server (${report.facts.length})`, value: block, inline: false });
+            } else {
+                embed.addFields({ name: 'Facts about you in this server', value: 'None stored.', inline: false });
+            }
+
+            embed.addFields({
+                name: 'Your memories in this server',
+                value: report.memories.count > 0
+                    ? `${report.memories.count} remembered messages (oldest ${report.memories.oldest?.split(' ')[0]}, newest ${report.memories.newest?.split(' ')[0]})`
+                    : 'None stored.',
+                inline: false
+            });
+
+            if (report.followups.length > 0) {
+                embed.addFields({
+                    name: `Pending follow-ups about you (${report.followups.length})`,
+                    value: report.followups.map(f => `- [${f.dueAt} UTC] ${f.note}`).join('\n').slice(0, 1024),
+                    inline: false
+                });
+            }
+
+            const misc = [
+                `**Nickname:** ${report.nickname || 'none set'}`,
+                `**Preferences:** ${report.preferences ? `meme mode ${report.preferences.memeMode ? 'on' : 'off'}, preset "${report.preferences.personality_preset}"` : 'none stored'}`,
+                `**Profile:** ${report.profile ? `created ${report.profile.joinedAt}` : 'none (you never ran /createuser or chatted)'}`,
+                `**Chat history (bot-wide):** ${report.conversations.count} conversations, ${report.conversations.messages} messages`,
+                `**Usage rows in this server:** ${report.usageRows} (token counts for cost tracking)`
+            ];
+            embed.addFields({ name: 'Everything else', value: misc.join('\n'), inline: false });
+
+            await interaction.editReply({ embeds: [embed] });
+        } catch (error) {
+            console.error('Data report failed:', error);
+            await interaction.editReply(`❌ Couldn't build your report: ${error.message}`);
+        }
+    }
+};

--- a/db/index.js
+++ b/db/index.js
@@ -98,6 +98,7 @@ function applyColumnMigrations(database) {
     ensureColumn('guild_settings', 'ai_provider', 'ai_provider TEXT');
     ensureColumn('guild_settings', 'ai_model', 'ai_model TEXT');
     ensureColumn('guild_settings', 'ai_reasoning_effort', 'ai_reasoning_effort TEXT');
+    ensureColumn('guild_settings', 'memory_retention_days', 'memory_retention_days INTEGER');
 }
 
 /**

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -102,6 +102,8 @@ CREATE TABLE IF NOT EXISTS guild_settings (
     ai_provider TEXT,
     ai_model TEXT,
     ai_reasoning_effort TEXT,
+    -- NULL = keep long-term memories forever; N = purge raw memories older than N days
+    memory_retention_days INTEGER,
     createdAt TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updatedAt TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
@@ -151,6 +153,14 @@ CREATE TABLE IF NOT EXISTS automations (
 CREATE INDEX IF NOT EXISTS idx_automations_guild ON automations(guildId);
 CREATE INDEX IF NOT EXISTS idx_automations_user ON automations(userId);
 CREATE INDEX IF NOT EXISTS idx_automations_next_run ON automations(nextRun);
+
+-- Channels the bot must not remember (privacy scope control, managed via /privacy)
+CREATE TABLE IF NOT EXISTS memory_channel_exclusions (
+    guildId TEXT NOT NULL,
+    channelId TEXT NOT NULL,
+    createdAt TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (guildId, channelId)
+);
 
 -- ---------------------------------------------------------------------------
 -- Long-term semantic memory (embeddings for cosine-similarity recall)
@@ -205,6 +215,22 @@ CREATE TABLE IF NOT EXISTS followups (
 );
 
 CREATE INDEX IF NOT EXISTS idx_followups_due ON followups(status, dueAt);
+
+-- ---------------------------------------------------------------------------
+-- Command usage counters (baseline metrics, e.g. /recall WAU)
+-- ---------------------------------------------------------------------------
+
+-- userId/guildId are Discord snowflakes (TEXT). One row per command invocation.
+CREATE TABLE IF NOT EXISTS command_log (
+    id INTEGER PRIMARY KEY,
+    guildId TEXT,
+    userId TEXT,
+    command TEXT NOT NULL,
+    createdAt TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_command_log_command_time ON command_log(command, createdAt);
+CREATE INDEX IF NOT EXISTS idx_command_log_guild_time ON command_log(guildId, createdAt);
 
 -- ---------------------------------------------------------------------------
 -- AI usage tracking (token counts per call)

--- a/documentation/commands.md
+++ b/documentation/commands.md
@@ -58,6 +58,34 @@ This document provides detailed information about all available commands in the 
 - **Description**: Lists all your saved prompts
 - **Usage**: `/viewprompts`
 
+### `/recall`
+- **Description**: Ask the server's long-term memory anything. Retrieves relevant remembered messages (semantic search over the local SQLite memory store), filters out channels you can't see, and answers grounded in those memories with source snippets
+- **Options**:
+  - `question` (required): What you want to know
+- **Usage**: `/recall question:what did we decide about the minecraft server?`
+
+## Privacy Commands
+
+### `/what-do-you-know-about-me`
+- **Description**: Private (ephemeral) report of everything Goobster has stored about you: facts, memory counts, pending follow-ups, nickname, preferences, chat history totals, and usage rows
+- **Usage**: `/what-do-you-know-about-me`
+
+### `/forget-me`
+- **Description**: Permanently erases everything Goobster knows about you, bot-wide, after a button confirmation. Deletes your memories, facts, follow-ups, chat history, nicknames, preferences, and profile; anonymizes usage rows (token counts kept); and scans server facts, conversation summaries, and follow-up notes for mentions of your name, deleting matches. Ends with a post-erasure audit showing zero rows still attributed to you
+- **Usage**: `/forget-me`
+
+### `/privacy`
+- **Description**: Admin controls for what Goobster remembers (requires Manage Server)
+- **Subcommands**:
+  - `status`: Show retention window, excluded channels, and stored memory count
+  - `retention`: Auto-delete long-term memories older than N days
+    - `days` (required): Days to keep memories (0 = keep forever). Applies immediately and nightly
+  - `exclude`: Stop remembering a channel and purge what's already stored from it
+    - `channel` (required): The channel Goobster must not remember
+  - `include`: Resume remembering a previously excluded channel
+    - `channel` (required): The channel to remember again
+- **Usage**: `/privacy retention days:90`, `/privacy exclude channel:#venting`
+
 ## Search Commands
 
 ### `/search`

--- a/documentation/development_standards_and_project_goals.md
+++ b/documentation/development_standards_and_project_goals.md
@@ -37,6 +37,16 @@ Goobster is a self-hostable Discord bot designed to provide engaging AI chat, he
 - `services/memoryService.js` stores message embeddings in the `memory_embeddings` SQLite table and recalls them by cosine similarity (`services/embeddingService.js`: OpenAI `text-embedding-3-small`, or Ollama `nomic-embed-text` when self-hosted).
 - Memory writes are fire-and-forget (never block or fail a reply); recall injects a `LONG-TERM MEMORY` block into the system prompt, excluding content already in the active context window.
 - Vectors are only compared when produced by the same embedding model; per-guild storage is capped (default 5000 entries) and admins can inspect/clear via `/memory`.
+- `/recall <question>` exposes memory directly ("ask the server anything"): retrieves relevant memories, filters out ones from channels the asking user cannot view, and synthesizes a grounded answer with source snippets. Invocations are counted in `command_log` (via `usageTracker.logCommand`) and surfaced in `/usage`.
+
+### Privacy controls (product features, not just positioning)
+- `/what-do-you-know-about-me` — per-user transparency report (ephemeral): facts, memory counts, pending follow-ups, nickname, preferences, chat-history totals, usage rows. Built by `services/privacyService.js` `buildUserReport`.
+- `/forget-me` — full per-user erasure (button-confirmed, bot-wide, single transaction) via `privacyService.forgetUser`:
+  - **Deletes:** `memory_embeddings` by `authorId`, USER-subject `facts`, `followups` created by the user, the user's conversation history (`messages`, `conversations`, `prompts`), `user_nicknames`, `UserPreferences`, and the `users` row.
+  - **Anonymizes:** `usage_log`/`command_log` rows (userId nulled, token counts kept for cost accounting).
+  - **Review pass:** GUILD-subject `facts`, `conversation_summaries`, and follow-up notes are scanned for the user's known names (username, display names, stored nicknames, memory author names) with word-boundary matching, and matches are deleted. Never skip this pass.
+  - `privacyService.auditUser` re-counts user-attributed rows afterwards; the command reports the audit so "zero gaps" is provable.
+- `/privacy` (Manage Server) — retention and scope: `retention days:<n>` sets `guild_settings.memory_retention_days` (purged on write and nightly from the consolidation run via `memoryService.applyRetentionAll`); `exclude`/`include channel:<c>` manage `memory_channel_exclusions` (excluding also purges that channel's stored memories; `memoryService.remember` refuses excluded channels before embedding).
 
 ### Usage tracking, vision, per-guild AI, and digests
 - `services/usageTracker.js` logs token counts for every AI call (`usage_log` table); providers report usage automatically (including streaming and Ollama), with attribution threaded via `opts.usageContext = { guildId, userId }`. `/usage` shows per-guild summaries.
@@ -103,7 +113,7 @@ The adventure mode (party/story system) and mystery heroes mode were retired to 
 - Keep this document authoritative and current
 
 ### Testing
-- Unit tests for core functionality (Jest)
+- Unit tests for core functionality (Jest). Specs live in `tests/*.test.js`; DB-backed specs point `GOOBSTER_DB_PATH` at a throwaway file (see `tests/privacyService.test.js`)
 - Smoke test: every module must `require()` cleanly with an empty/minimal config
 - Integration tests for key features
 

--- a/documentation/differentiation_strategy.md
+++ b/documentation/differentiation_strategy.md
@@ -95,6 +95,8 @@ To keep the roadmap disciplined, these stay off the board until Tier 1 has shipp
 ## Roadmap framing
 
 - **Now:** `/recall`, Server Wrapped MVP, privacy commands (`/what-do-you-know-about-me`, `/forget-me`, retention settings), and fixing the test runner (see Verification)
+  - ✅ Shipped: `/recall` (with channel-visibility filtering and a `command_log` usage counter surfaced in `/usage`), `/what-do-you-know-about-me`, `/forget-me` (full deletion scope below, incl. the name-mention review pass and a post-erasure audit), `/privacy` retention + channel exclusions, and real Jest specs (`npm test` passes).
+  - ⏳ Still open in "Now": Server Wrapped MVP.
 - **Next:** Scene Director MVP (audio-pipeline Pi benchmark first)
 - **Later:** Offline voice beta + Pi 4B benchmark table; then Home Assistant bridge with guardrails
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2132,9 +2132,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2150,9 +2147,6 @@
       "integrity": "sha512-ptRbLSQxtV6EjXppS5z7qaPDI0NRKhrkJYsTlAjEghmOvlAObozSCYYnMO6nbkt6Ab3+lWqyahClzcRNcD2ouw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2170,9 +2164,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2188,9 +2179,6 @@
       "integrity": "sha512-LLNnO+hfG41ymeI+O1YHo5/0h3aKaetUNLdkBwpdJsjoyKMXZaeCnB+aHNkkupJCMPmWS0g6iPMCHUOqZSBcTg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/services/memoryConsolidationService.js
+++ b/services/memoryConsolidationService.js
@@ -44,6 +44,16 @@ class MemoryConsolidationService {
         if (this.running) return;
         this.running = true;
         try {
+            // Nightly retention purge (guilds with /privacy retention configured)
+            try {
+                const purged = require('./memoryService').applyRetentionAll();
+                if (purged > 0) {
+                    console.log(`[Consolidation] Retention purge removed ${purged} memories`);
+                }
+            } catch (error) {
+                console.warn('[Consolidation] Retention purge failed:', error.message);
+            }
+
             const guilds = db.all(
                 `SELECT DISTINCT guildId FROM memory_embeddings
                  WHERE createdAt >= datetime('now', '-1 day')`

--- a/services/memoryService.js
+++ b/services/memoryService.js
@@ -28,6 +28,7 @@ class MemoryService {
     async remember({ guildId, channelId, authorId, authorName, content }) {
         try {
             if (!this.isEnabled() || !guildId || !content) return false;
+            if (channelId && this.isChannelExcluded(guildId, channelId)) return false;
 
             const trimmed = content.trim();
             if (trimmed.length < MIN_CONTENT_LENGTH || trimmed.startsWith('/')) return false;
@@ -67,7 +68,8 @@ class MemoryService {
     }
 
     /**
-     * Keep each guild's memory bounded by deleting the oldest entries.
+     * Keep each guild's memory bounded by deleting the oldest entries, and
+     * apply the guild's retention window when one is configured.
      */
     _prune(guildId) {
         const max = aiConfig.memory.maxEntriesPerGuild;
@@ -81,6 +83,86 @@ class MemoryService {
                )`,
             { guildId, max }
         );
+        this.applyRetention(guildId);
+    }
+
+    /**
+     * Purge memories older than the guild's retention window (if set).
+     * @returns {number} rows removed
+     */
+    applyRetention(guildId) {
+        const row = db.get(
+            'SELECT memory_retention_days FROM guild_settings WHERE guildId = @guildId',
+            { guildId }
+        );
+        const days = row?.memory_retention_days;
+        if (!days || days <= 0) return 0;
+
+        return db.run(
+            `DELETE FROM memory_embeddings
+             WHERE guildId = @guildId
+               AND createdAt < datetime('now', '-' || @days || ' days')`,
+            { guildId, days }
+        ).changes;
+    }
+
+    /**
+     * Apply retention for every guild that has a window configured. Runs from
+     * the nightly consolidation pass so quiet guilds still get purged.
+     * @returns {number} total rows removed
+     */
+    applyRetentionAll() {
+        const guilds = db.all(
+            `SELECT guildId FROM guild_settings
+             WHERE memory_retention_days IS NOT NULL AND memory_retention_days > 0`
+        );
+        let removed = 0;
+        for (const { guildId } of guilds) {
+            removed += this.applyRetention(guildId);
+        }
+        return removed;
+    }
+
+    /**
+     * Channels the bot must not remember (privacy scope control).
+     */
+    isChannelExcluded(guildId, channelId) {
+        return Boolean(db.get(
+            `SELECT 1 FROM memory_channel_exclusions
+             WHERE guildId = @guildId AND channelId = @channelId`,
+            { guildId, channelId }
+        ));
+    }
+
+    excludeChannel(guildId, channelId) {
+        db.run(
+            `INSERT INTO memory_channel_exclusions (guildId, channelId)
+             VALUES (@guildId, @channelId)
+             ON CONFLICT(guildId, channelId) DO NOTHING`,
+            { guildId, channelId }
+        );
+        // Drop anything already remembered from that channel
+        return db.run(
+            `DELETE FROM memory_embeddings
+             WHERE guildId = @guildId AND channelId = @channelId`,
+            { guildId, channelId }
+        ).changes;
+    }
+
+    includeChannel(guildId, channelId) {
+        return db.run(
+            `DELETE FROM memory_channel_exclusions
+             WHERE guildId = @guildId AND channelId = @channelId`,
+            { guildId, channelId }
+        ).changes;
+    }
+
+    getExcludedChannels(guildId) {
+        return db.all(
+            `SELECT channelId FROM memory_channel_exclusions
+             WHERE guildId = @guildId ORDER BY createdAt ASC`,
+            { guildId }
+        ).map(r => r.channelId);
     }
 
     /**
@@ -101,7 +183,7 @@ class MemoryService {
 
             // Only compare vectors from the same embedding model
             const rows = db.all(
-                `SELECT content, authorName, createdAt, embedding, dims
+                `SELECT content, authorName, channelId, createdAt, embedding, dims
                  FROM memory_embeddings
                  WHERE guildId = @guildId AND model = @model
                  ORDER BY id DESC LIMIT @max`,
@@ -121,6 +203,7 @@ class MemoryService {
                     scored.push({
                         content: row.content,
                         authorName: row.authorName,
+                        channelId: row.channelId,
                         createdAt: row.createdAt,
                         similarity
                     });
@@ -178,6 +261,30 @@ ${lines.join('\n')}`;
     forgetGuild(guildId) {
         const result = db.run('DELETE FROM memory_embeddings WHERE guildId = @guildId', { guildId });
         return result.changes;
+    }
+
+    /**
+     * Count memories authored by a user in a guild.
+     */
+    countUserMemories(guildId, authorId) {
+        const row = db.get(
+            `SELECT COUNT(*) AS count FROM memory_embeddings
+             WHERE guildId = @guildId AND authorId = @authorId`,
+            { guildId, authorId }
+        );
+        return row?.count || 0;
+    }
+
+    /**
+     * Delete all memories authored by a user in a guild (per-user erasure).
+     * @returns {number} rows removed
+     */
+    forgetUser(guildId, authorId) {
+        return db.run(
+            `DELETE FROM memory_embeddings
+             WHERE guildId = @guildId AND authorId = @authorId`,
+            { guildId, authorId }
+        ).changes;
     }
 }
 

--- a/services/privacyService.js
+++ b/services/privacyService.js
@@ -1,0 +1,293 @@
+const db = require('../db');
+
+/**
+ * Privacy controls as product features: the data transparency report behind
+ * /what-do-you-know-about-me and the full per-user erasure behind /forget-me.
+ *
+ * Erasure scope (see documentation/differentiation_strategy.md):
+ * - DELETE: memory_embeddings (by authorId), facts (USER-subject), followups
+ *   created by or about the user, conversation history (messages,
+ *   conversations, prompts), user_nicknames, UserPreferences, users row.
+ * - ANONYMIZE: usage_log / command_log rows (userId nulled, counts kept).
+ * - REVIEW: GUILD-subject facts and conversation_summaries that mention the
+ *   user by name without carrying their ID are scanned and deleted too.
+ *
+ * The bot's users/conversations tables are global (not per-guild), so
+ * /forget-me erases the user across the whole bot instance - the honest
+ * interpretation of "forget me" for a self-hosted bot.
+ */
+class PrivacyService {
+    /**
+     * Names the user is known by: username, display names, stored nicknames,
+     * and the author names attached to their memories. Used for the
+     * name-mention review scan.
+     * @param {Object} params - { userId, extraNames: string[] }
+     * @returns {string[]} unique, trimmed names (length >= 2)
+     */
+    collectKnownNames({ userId, extraNames = [] }) {
+        const names = new Set();
+
+        for (const name of extraNames) {
+            if (name) names.add(String(name).trim());
+        }
+
+        const nicknameRows = db.all(
+            'SELECT nickname FROM user_nicknames WHERE userId = @userId',
+            { userId }
+        );
+        for (const row of nicknameRows) names.add(String(row.nickname).trim());
+
+        const authorRows = db.all(
+            `SELECT DISTINCT authorName FROM memory_embeddings
+             WHERE authorId = @userId AND authorName IS NOT NULL`,
+            { userId }
+        );
+        for (const row of authorRows) names.add(String(row.authorName).trim());
+
+        const userRow = db.get(
+            'SELECT discordUsername, username FROM users WHERE discordId = @userId',
+            { userId }
+        );
+        if (userRow?.discordUsername) names.add(String(userRow.discordUsername).trim());
+        if (userRow?.username) names.add(String(userRow.username).trim());
+
+        return [...names].filter(n => n.length >= 2);
+    }
+
+    /**
+     * Build a case-insensitive regex matching any known name on word
+     * boundaries (so "Rob" doesn't match "problem").
+     * @returns {RegExp|null} null when there are no usable names
+     */
+    _buildNameMatcher(names) {
+        if (!names || names.length === 0) return null;
+        const escaped = names.map(n => n.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+        return new RegExp(`(^|[^\\p{L}\\p{N}])(${escaped.join('|')})($|[^\\p{L}\\p{N}])`, 'iu');
+    }
+
+    /**
+     * Everything Goobster knows about a user, for the transparency report.
+     * Guild-scoped tables report the current guild; global tables report
+     * bot-wide totals.
+     * @param {Object} params - { guildId, userId }
+     */
+    buildUserReport({ guildId, userId }) {
+        const facts = db.all(
+            `SELECT content, source, updatedAt FROM facts
+             WHERE guildId = @guildId AND subjectType = 'USER' AND subjectId = @userId
+             ORDER BY updatedAt DESC, id DESC`,
+            { guildId, userId }
+        );
+
+        const memories = db.get(
+            `SELECT COUNT(*) AS count, MIN(createdAt) AS oldest, MAX(createdAt) AS newest
+             FROM memory_embeddings WHERE guildId = @guildId AND authorId = @userId`,
+            { guildId, userId }
+        );
+
+        const followups = db.all(
+            `SELECT note, dueAt FROM followups
+             WHERE guildId = @guildId AND userId = @userId AND status = 'PENDING'
+             ORDER BY dueAt ASC`,
+            { guildId, userId }
+        );
+
+        const nickname = db.get(
+            'SELECT nickname FROM user_nicknames WHERE guildId = @guildId AND userId = @userId',
+            { guildId, userId }
+        );
+
+        const preferences = db.get(
+            'SELECT memeMode, personality_preset FROM UserPreferences WHERE userId = @userId',
+            { userId }
+        );
+
+        const userRow = db.get('SELECT id, joinedAt FROM users WHERE discordId = @userId', { userId });
+        const conversations = userRow
+            ? db.get(
+                `SELECT COUNT(DISTINCT c.id) AS conversationCount, COUNT(m.id) AS messageCount
+                 FROM conversations c
+                 LEFT JOIN messages m ON m.conversationId = c.id
+                 WHERE c.userId = @internalId`,
+                { internalId: userRow.id }
+            )
+            : { conversationCount: 0, messageCount: 0 };
+
+        const usage = db.get(
+            `SELECT COUNT(*) AS count FROM usage_log
+             WHERE guildId = @guildId AND userId = @userId`,
+            { guildId, userId }
+        );
+
+        return {
+            facts,
+            memories: {
+                count: memories?.count || 0,
+                oldest: memories?.oldest || null,
+                newest: memories?.newest || null
+            },
+            followups,
+            nickname: nickname?.nickname || null,
+            preferences: preferences || null,
+            profile: userRow ? { joinedAt: userRow.joinedAt } : null,
+            conversations: {
+                count: conversations?.conversationCount || 0,
+                messages: conversations?.messageCount || 0
+            },
+            usageRows: usage?.count || 0
+        };
+    }
+
+    /**
+     * Full per-user erasure across the bot instance. Synchronous by design so
+     * the whole thing commits (or rolls back) as one transaction.
+     * @param {Object} params - { userId, extraNames: string[] }
+     * @returns {Object} per-table deletion/anonymization counts
+     */
+    forgetUser({ userId, extraNames = [] }) {
+        // Collect names BEFORE deleting the rows they come from
+        const knownNames = this.collectKnownNames({ userId, extraNames });
+        const nameMatcher = this._buildNameMatcher(knownNames);
+
+        return db.transaction(() => {
+            const counts = { knownNames };
+
+            counts.memories = db.run(
+                'DELETE FROM memory_embeddings WHERE authorId = @userId', { userId }
+            ).changes;
+
+            counts.userFacts = db.run(
+                `DELETE FROM facts WHERE subjectType = 'USER' AND subjectId = @userId`,
+                { userId }
+            ).changes;
+
+            // Follow-ups created by/about the user (any status - erasure is erasure)
+            counts.followups = db.run(
+                'DELETE FROM followups WHERE userId = @userId', { userId }
+            ).changes;
+
+            // Review pass 1: GUILD-subject facts that mention the user by name
+            counts.reviewedGuildFacts = 0;
+            if (nameMatcher) {
+                const guildFacts = db.all(
+                    `SELECT id, content FROM facts WHERE subjectType = 'GUILD'`
+                );
+                for (const fact of guildFacts) {
+                    if (nameMatcher.test(fact.content)) {
+                        db.run('DELETE FROM facts WHERE id = @id', { id: fact.id });
+                        counts.reviewedGuildFacts++;
+                    }
+                }
+
+                // Review pass 2: conversation summaries mentioning the user
+                counts.reviewedSummaries = 0;
+                const summaries = db.all('SELECT id, summary FROM conversation_summaries');
+                for (const row of summaries) {
+                    if (nameMatcher.test(row.summary)) {
+                        db.run('DELETE FROM conversation_summaries WHERE id = @id', { id: row.id });
+                        counts.reviewedSummaries++;
+                    }
+                }
+
+                // Review pass 3: follow-up notes mentioning the user by name
+                const notes = db.all('SELECT id, note FROM followups');
+                for (const row of notes) {
+                    if (nameMatcher.test(row.note)) {
+                        db.run('DELETE FROM followups WHERE id = @id', { id: row.id });
+                        counts.followups++;
+                    }
+                }
+            } else {
+                counts.reviewedSummaries = 0;
+            }
+
+            // Conversation history: the user's conversations (including bot
+            // replies inside them), any stray messages they authored, their
+            // prompts, then the users row itself.
+            counts.messages = 0;
+            counts.conversations = 0;
+            counts.prompts = 0;
+            const userRow = db.get('SELECT id FROM users WHERE discordId = @userId', { userId });
+            if (userRow) {
+                const internalId = userRow.id;
+                db.run('UPDATE users SET activeConversationId = NULL WHERE id = @internalId', { internalId });
+                counts.messages += db.run(
+                    `DELETE FROM messages WHERE conversationId IN
+                        (SELECT id FROM conversations WHERE userId = @internalId)`,
+                    { internalId }
+                ).changes;
+                counts.messages += db.run(
+                    'DELETE FROM messages WHERE createdBy = @internalId', { internalId }
+                ).changes;
+                counts.conversations = db.run(
+                    'DELETE FROM conversations WHERE userId = @internalId', { internalId }
+                ).changes;
+                counts.prompts = db.run(
+                    'DELETE FROM prompts WHERE userId = @internalId', { internalId }
+                ).changes;
+                db.run('DELETE FROM users WHERE id = @internalId', { internalId });
+                counts.profile = 1;
+            } else {
+                counts.profile = 0;
+            }
+
+            counts.nicknames = db.run(
+                'DELETE FROM user_nicknames WHERE userId = @userId', { userId }
+            ).changes;
+
+            counts.preferences = db.run(
+                'DELETE FROM UserPreferences WHERE userId = @userId', { userId }
+            ).changes;
+
+            // Anonymize, don't delete: cost accounting keeps its token counts
+            counts.anonymizedUsageRows = db.run(
+                'UPDATE usage_log SET userId = NULL WHERE userId = @userId', { userId }
+            ).changes;
+            counts.anonymizedUsageRows += db.run(
+                'UPDATE command_log SET userId = NULL WHERE userId = @userId', { userId }
+            ).changes;
+
+            return counts;
+        });
+    }
+
+    /**
+     * Post-erasure audit: count rows still attributed to the user. Used by
+     * tests and surfaced after /forget-me so "zero gaps" is provable.
+     * @returns {{total: number, byTable: Object}}
+     */
+    auditUser({ userId }) {
+        const byTable = {
+            memory_embeddings: db.get(
+                'SELECT COUNT(*) AS c FROM memory_embeddings WHERE authorId = @userId', { userId }
+            ).c,
+            facts: db.get(
+                `SELECT COUNT(*) AS c FROM facts WHERE subjectType = 'USER' AND subjectId = @userId`,
+                { userId }
+            ).c,
+            followups: db.get(
+                'SELECT COUNT(*) AS c FROM followups WHERE userId = @userId', { userId }
+            ).c,
+            users: db.get(
+                'SELECT COUNT(*) AS c FROM users WHERE discordId = @userId', { userId }
+            ).c,
+            user_nicknames: db.get(
+                'SELECT COUNT(*) AS c FROM user_nicknames WHERE userId = @userId', { userId }
+            ).c,
+            UserPreferences: db.get(
+                'SELECT COUNT(*) AS c FROM UserPreferences WHERE userId = @userId', { userId }
+            ).c,
+            usage_log: db.get(
+                'SELECT COUNT(*) AS c FROM usage_log WHERE userId = @userId', { userId }
+            ).c,
+            command_log: db.get(
+                'SELECT COUNT(*) AS c FROM command_log WHERE userId = @userId', { userId }
+            ).c
+        };
+
+        const total = Object.values(byTable).reduce((sum, c) => sum + c, 0);
+        return { total, byTable };
+    }
+}
+
+module.exports = new PrivacyService();

--- a/services/usageTracker.js
+++ b/services/usageTracker.js
@@ -35,6 +35,59 @@ class UsageTracker {
     }
 
     /**
+     * Record one command invocation (baseline metrics, e.g. /recall WAU).
+     * Never breaks the command on failure.
+     * @param {Object} entry - { command, guildId, userId }
+     */
+    logCommand({ command, guildId = null, userId = null }) {
+        try {
+            db.run(
+                `INSERT INTO command_log (guildId, userId, command)
+                 VALUES (@guildId, @userId, @command)`,
+                { guildId, userId, command }
+            );
+        } catch (error) {
+            console.warn('[UsageTracker] Failed to log command:', error.message);
+        }
+    }
+
+    /**
+     * Command usage for a window: total invocations and unique users.
+     * @param {Object} params - { command, guildId (null = all guilds), days }
+     * @returns {{calls: number, uniqueUsers: number}}
+     */
+    getCommandStats({ command, guildId = null, days = 7 }) {
+        const guildFilter = guildId ? 'AND guildId = @guildId' : '';
+        const row = db.get(
+            `SELECT COUNT(*) AS calls, COUNT(DISTINCT userId) AS uniqueUsers
+             FROM command_log
+             WHERE command = @command
+               AND createdAt >= datetime('now', '-' || @days || ' days') ${guildFilter}`,
+            { command, guildId, days }
+        );
+        return { calls: row?.calls || 0, uniqueUsers: row?.uniqueUsers || 0 };
+    }
+
+    /**
+     * Anonymize a user's usage rows (GDPR-style erasure): null the userId,
+     * keep token counts so cost accounting stays intact.
+     * @returns {number} rows anonymized
+     */
+    anonymizeUser({ guildId, userId }) {
+        let changes = db.run(
+            `UPDATE usage_log SET userId = NULL
+             WHERE guildId = @guildId AND userId = @userId`,
+            { guildId, userId }
+        ).changes;
+        changes += db.run(
+            `UPDATE command_log SET userId = NULL
+             WHERE guildId = @guildId AND userId = @userId`,
+            { guildId, userId }
+        ).changes;
+        return changes;
+    }
+
+    /**
      * Per-model summary for a window.
      * @param {Object} params - { guildId (null = all guilds), days }
      * @returns {Array<{provider, model, operation, calls, inputTokens, outputTokens}>}

--- a/tests/memoryPrivacy.test.js
+++ b/tests/memoryPrivacy.test.js
@@ -1,0 +1,113 @@
+/**
+ * Unit tests for memory privacy controls (channel exclusions, retention) and
+ * the command usage counter, against a throwaway SQLite database.
+ */
+const path = require('node:path');
+const os = require('node:os');
+const fs = require('node:fs');
+
+const TEST_DB = path.join(os.tmpdir(), `goobster-memory-test-${process.pid}.sqlite`);
+process.env.GOOBSTER_DB_PATH = TEST_DB;
+
+const db = require('../db');
+const memoryService = require('../services/memoryService');
+const usageTracker = require('../services/usageTracker');
+
+const GUILD = '300000000000000001';
+const CHANNEL = '400000000000000001';
+
+function insertMemory({ channelId = null, content, ageDays = 0 }) {
+    db.run(
+        `INSERT INTO memory_embeddings (guildId, channelId, authorId, authorName, content, embedding, dims, model, createdAt)
+         VALUES (@g, @c, 'u1', 'Someone', @content, x'00000000', 1, 'test/model', datetime('now', '-' || @ageDays || ' days'))`,
+        { g: GUILD, c: channelId, content, ageDays }
+    );
+}
+
+afterAll(async () => {
+    await db.closeConnection();
+    for (const suffix of ['', '-shm', '-wal']) {
+        fs.rmSync(TEST_DB + suffix, { force: true });
+    }
+});
+
+describe('channel exclusions', () => {
+    test('remember() refuses excluded channels without touching the embedder', async () => {
+        memoryService.excludeChannel(GUILD, CHANNEL);
+        expect(memoryService.isChannelExcluded(GUILD, CHANNEL)).toBe(true);
+
+        const stored = await memoryService.remember({
+            guildId: GUILD,
+            channelId: CHANNEL,
+            authorId: 'u1',
+            authorName: 'Someone',
+            content: 'a secret long enough to pass the length filter'
+        });
+        expect(stored).toBe(false);
+        expect(db.get('SELECT COUNT(*) AS c FROM memory_embeddings WHERE guildId = @g', { g: GUILD }).c).toBe(0);
+    });
+
+    test('excluding a channel purges memories already stored from it', () => {
+        memoryService.includeChannel(GUILD, CHANNEL);
+        insertMemory({ channelId: CHANNEL, content: 'stored before exclusion' });
+        insertMemory({ channelId: 'other-channel', content: 'different channel' });
+
+        const removed = memoryService.excludeChannel(GUILD, CHANNEL);
+        expect(removed).toBe(1);
+
+        const remaining = db.all('SELECT content FROM memory_embeddings WHERE guildId = @g', { g: GUILD });
+        expect(remaining.map(r => r.content)).toEqual(['different channel']);
+    });
+
+    test('include/exclude round-trips through getExcludedChannels', () => {
+        expect(memoryService.getExcludedChannels(GUILD)).toEqual([CHANNEL]);
+        memoryService.includeChannel(GUILD, CHANNEL);
+        expect(memoryService.getExcludedChannels(GUILD)).toEqual([]);
+    });
+});
+
+describe('retention', () => {
+    test('applyRetention deletes only memories older than the window', () => {
+        db.run(
+            `INSERT INTO guild_settings (guildId, memory_retention_days) VALUES (@g, 30)
+             ON CONFLICT(guildId) DO UPDATE SET memory_retention_days = 30`,
+            { g: GUILD }
+        );
+        insertMemory({ content: 'ancient memory', ageDays: 45 });
+        insertMemory({ content: 'fresh memory', ageDays: 5 });
+
+        const removed = memoryService.applyRetention(GUILD);
+        expect(removed).toBe(1);
+
+        const contents = db.all('SELECT content FROM memory_embeddings WHERE guildId = @g', { g: GUILD }).map(r => r.content);
+        expect(contents).toContain('fresh memory');
+        expect(contents).not.toContain('ancient memory');
+    });
+
+    test('no retention window means nothing is deleted', () => {
+        db.run('UPDATE guild_settings SET memory_retention_days = NULL WHERE guildId = @g', { g: GUILD });
+        insertMemory({ content: 'very old but kept', ageDays: 400 });
+        expect(memoryService.applyRetention(GUILD)).toBe(0);
+    });
+
+    test('applyRetentionAll covers every guild with a window set', () => {
+        db.run('UPDATE guild_settings SET memory_retention_days = 30 WHERE guildId = @g', { g: GUILD });
+        expect(memoryService.applyRetentionAll()).toBe(1); // the 400-day-old row
+    });
+});
+
+describe('command counter', () => {
+    test('logCommand + getCommandStats count calls and unique users', () => {
+        usageTracker.logCommand({ command: 'recall', guildId: GUILD, userId: 'u1' });
+        usageTracker.logCommand({ command: 'recall', guildId: GUILD, userId: 'u1' });
+        usageTracker.logCommand({ command: 'recall', guildId: GUILD, userId: 'u2' });
+        usageTracker.logCommand({ command: 'other', guildId: GUILD, userId: 'u3' });
+
+        const stats = usageTracker.getCommandStats({ command: 'recall', guildId: GUILD, days: 7 });
+        expect(stats.calls).toBe(3);
+        expect(stats.uniqueUsers).toBe(2);
+
+        const allGuilds = usageTracker.getCommandStats({ command: 'recall', days: 7 });
+        expect(allGuilds.calls).toBe(3);
+    });
+});

--- a/tests/privacyService.test.js
+++ b/tests/privacyService.test.js
@@ -1,0 +1,150 @@
+/**
+ * Unit tests for the /forget-me erasure scope and /what-do-you-know-about-me
+ * report (services/privacyService.js), against a throwaway SQLite database.
+ */
+const path = require('node:path');
+const os = require('node:os');
+const fs = require('node:fs');
+
+const TEST_DB = path.join(os.tmpdir(), `goobster-privacy-test-${process.pid}.sqlite`);
+process.env.GOOBSTER_DB_PATH = TEST_DB;
+
+const db = require('../db');
+const privacyService = require('../services/privacyService');
+
+const USER = '100000000000000001';   // erased user (Discord snowflake)
+const OTHER = '100000000000000002';  // must remain untouched
+const GUILD = '200000000000000001';
+
+function seed() {
+    // users / conversations / messages / prompts (internal integer ids)
+    db.run(`INSERT INTO users (discordUsername, discordId, username) VALUES ('rob', @id, 'rob')`, { id: USER });
+    db.run(`INSERT INTO users (discordUsername, discordId, username) VALUES ('alice', @id, 'alice')`, { id: OTHER });
+    const rob = db.get('SELECT id FROM users WHERE discordId = @id', { id: USER }).id;
+    const alice = db.get('SELECT id FROM users WHERE discordId = @id', { id: OTHER }).id;
+
+    db.run(`INSERT INTO prompts (userId, prompt) VALUES (@rob, 'be nice')`, { rob });
+    db.run(`INSERT INTO conversations (id, userId) VALUES (10, @rob)`, { rob });
+    db.run(`INSERT INTO conversations (id, userId) VALUES (20, @alice)`, { alice });
+    db.run(`UPDATE users SET activeConversationId = 10 WHERE id = @rob`, { rob });
+    db.run(`INSERT INTO messages (conversationId, message, isBot, createdBy) VALUES (10, 'hi from rob', 0, @rob)`, { rob });
+    db.run(`INSERT INTO messages (conversationId, message, isBot, createdBy) VALUES (10, 'bot reply to rob', 1, @alice)`, { alice });
+    db.run(`INSERT INTO messages (conversationId, message, isBot, createdBy) VALUES (20, 'alice message', 0, @alice)`, { alice });
+
+    // memories
+    db.run(`INSERT INTO memory_embeddings (guildId, authorId, authorName, content, embedding, dims, model)
+            VALUES (@g, @u, 'Rob', 'rob memory', x'00000000', 1, 'test/model')`, { g: GUILD, u: USER });
+    db.run(`INSERT INTO memory_embeddings (guildId, authorId, authorName, content, embedding, dims, model)
+            VALUES (@g, @u, 'Alice', 'alice memory', x'00000000', 1, 'test/model')`, { g: GUILD, u: OTHER });
+
+    // facts: USER-subject, GUILD-subject mentioning Rob, GUILD not mentioning,
+    // and a word-boundary trap ("problem" contains "rob")
+    db.run(`INSERT INTO facts (guildId, subjectType, subjectId, content) VALUES (@g, 'USER', @u, 'Rob likes trains')`, { g: GUILD, u: USER });
+    db.run(`INSERT INTO facts (guildId, subjectType, content) VALUES (@g, 'GUILD', 'Rob runs the minecraft server')`, { g: GUILD });
+    db.run(`INSERT INTO facts (guildId, subjectType, content) VALUES (@g, 'GUILD', 'Movie night is on Fridays')`, { g: GUILD });
+    db.run(`INSERT INTO facts (guildId, subjectType, content) VALUES (@g, 'GUILD', 'The problem channel is for tech support')`, { g: GUILD });
+
+    // conversation summaries (one mentioning Rob by name)
+    db.run(`INSERT INTO guild_conversations (id, guildId, threadId, channelId) VALUES (5, @g, 't1', 'c1')`, { g: GUILD });
+    db.run(`INSERT INTO conversation_summaries (guildConversationId, summary, messageCount) VALUES (5, 'Rob talked about his Pi cluster', 10)`);
+    db.run(`INSERT INTO conversation_summaries (guildConversationId, summary, messageCount) VALUES (5, 'General chatter about games', 12)`);
+
+    // followups: created by Rob, about Rob by name, unrelated
+    db.run(`INSERT INTO followups (guildId, channelId, userId, note, dueAt) VALUES (@g, 'c1', @u, 'remind me to deploy', '2030-01-01 00:00:00')`, { g: GUILD, u: USER });
+    db.run(`INSERT INTO followups (guildId, channelId, userId, note, dueAt) VALUES (@g, 'c1', @o, 'ask Rob how the deploy went', '2030-01-01 00:00:00')`, { g: GUILD, o: OTHER });
+    db.run(`INSERT INTO followups (guildId, channelId, userId, note, dueAt) VALUES (@g, 'c1', @o, 'water the plants', '2030-01-01 00:00:00')`, { g: GUILD, o: OTHER });
+
+    // nicknames, preferences, usage, command log
+    db.run(`INSERT INTO user_nicknames (userId, guildId, nickname) VALUES (@u, @g, 'Robbo')`, { u: USER, g: GUILD });
+    db.run(`INSERT INTO UserPreferences (userId, memeMode) VALUES (@u, 1)`, { u: USER });
+    db.run(`INSERT INTO usage_log (guildId, userId, provider, model, operation, inputTokens, outputTokens)
+            VALUES (@g, @u, 'openai', 'gpt-test', 'chat', 100, 50)`, { g: GUILD, u: USER });
+    db.run(`INSERT INTO usage_log (guildId, userId, provider, model, operation, inputTokens, outputTokens)
+            VALUES (@g, @o, 'openai', 'gpt-test', 'chat', 10, 5)`, { g: GUILD, o: OTHER });
+    db.run(`INSERT INTO command_log (guildId, userId, command) VALUES (@g, @u, 'recall')`, { g: GUILD, u: USER });
+}
+
+beforeAll(() => {
+    seed();
+});
+
+afterAll(async () => {
+    await db.closeConnection();
+    for (const suffix of ['', '-shm', '-wal']) {
+        fs.rmSync(TEST_DB + suffix, { force: true });
+    }
+});
+
+describe('buildUserReport', () => {
+    test('reports facts, memories, followups, nickname, preferences, and history', () => {
+        const report = privacyService.buildUserReport({ guildId: GUILD, userId: USER });
+
+        expect(report.facts).toHaveLength(1);
+        expect(report.facts[0].content).toBe('Rob likes trains');
+        expect(report.memories.count).toBe(1);
+        expect(report.followups).toHaveLength(1);
+        expect(report.nickname).toBe('Robbo');
+        expect(report.preferences.memeMode).toBe(1);
+        expect(report.profile).not.toBeNull();
+        expect(report.conversations.count).toBe(1);
+        expect(report.conversations.messages).toBe(2);
+        expect(report.usageRows).toBe(1);
+    });
+});
+
+describe('forgetUser', () => {
+    let counts;
+
+    beforeAll(() => {
+        counts = privacyService.forgetUser({ userId: USER, extraNames: ['Rob'] });
+    });
+
+    test('deletes memories, facts, followups, history, nicknames, preferences, profile', () => {
+        expect(counts.memories).toBe(1);
+        expect(counts.userFacts).toBe(1);
+        expect(counts.messages).toBe(2); // rob's message + bot reply in his conversation
+        expect(counts.conversations).toBe(1);
+        expect(counts.prompts).toBe(1);
+        expect(counts.nicknames).toBe(1);
+        expect(counts.preferences).toBe(1);
+        expect(counts.profile).toBe(1);
+    });
+
+    test('review pass deletes name-mentions in guild facts, summaries, and followup notes', () => {
+        expect(counts.reviewedGuildFacts).toBe(1);
+        expect(counts.reviewedSummaries).toBe(1);
+        // 1 created by Rob + 1 note mentioning Rob
+        expect(counts.followups).toBe(2);
+
+        const remainingFacts = db.all(`SELECT content FROM facts WHERE subjectType = 'GUILD'`).map(r => r.content);
+        expect(remainingFacts).toContain('Movie night is on Fridays');
+        // word-boundary check: "problem" must survive a user named "rob"
+        expect(remainingFacts).toContain('The problem channel is for tech support');
+        expect(remainingFacts).not.toContain('Rob runs the minecraft server');
+
+        const remainingSummaries = db.all('SELECT summary FROM conversation_summaries').map(r => r.summary);
+        expect(remainingSummaries).toEqual(['General chatter about games']);
+
+        const remainingNotes = db.all('SELECT note FROM followups').map(r => r.note);
+        expect(remainingNotes).toEqual(['water the plants']);
+    });
+
+    test('anonymizes usage rows instead of deleting them', () => {
+        expect(counts.anonymizedUsageRows).toBe(2); // 1 usage_log + 1 command_log
+        const usage = db.all(`SELECT userId, inputTokens FROM usage_log ORDER BY inputTokens DESC`);
+        expect(usage).toHaveLength(2); // token counts kept
+        expect(usage[0]).toEqual({ userId: null, inputTokens: 100 });
+    });
+
+    test('leaves other users untouched', () => {
+        expect(db.get('SELECT COUNT(*) AS c FROM users WHERE discordId = @id', { id: OTHER }).c).toBe(1);
+        expect(db.get('SELECT COUNT(*) AS c FROM memory_embeddings WHERE authorId = @id', { id: OTHER }).c).toBe(1);
+        expect(db.get('SELECT COUNT(*) AS c FROM messages WHERE conversationId = 20').c).toBe(1);
+        expect(db.get('SELECT userId FROM usage_log WHERE inputTokens = 10').userId).toBe(OTHER);
+    });
+
+    test('post-erasure audit reports zero user-attributed rows', () => {
+        const audit = privacyService.auditUser({ userId: USER });
+        expect(audit.total).toBe(0);
+    });
+});

--- a/utils/guildSettings.js
+++ b/utils/guildSettings.js
@@ -244,6 +244,44 @@ async function setGuildAI(guildId, { provider, model, reasoningEffort } = {}) {
 }
 
 /**
+ * Gets the long-term memory retention window for a guild.
+ * @param {string} guildId - The Discord guild ID
+ * @returns {Promise<number|null>} - Days to keep memories, or null (keep forever)
+ */
+async function getMemoryRetentionDays(guildId) {
+    const cached = guildSettingsCache.get(guildId);
+    if (cached && cached.memoryRetentionDays !== undefined) {
+        return cached.memoryRetentionDays;
+    }
+
+    try {
+        const row = db.get(
+            'SELECT memory_retention_days FROM guild_settings WHERE guildId = @guildId',
+            { guildId }
+        );
+        const days = row?.memory_retention_days ?? null;
+        getCacheEntry(guildId).memoryRetentionDays = days;
+        return days;
+    } catch (error) {
+        console.error('Error getting memory retention setting:', error);
+        return null;
+    }
+}
+
+/**
+ * Sets the long-term memory retention window for a guild.
+ * @param {string} guildId - The Discord guild ID
+ * @param {number|null} days - Days to keep memories (null/0 = keep forever)
+ * @returns {Promise<number|null>} - The stored value
+ */
+async function setMemoryRetentionDays(guildId, days) {
+    const value = days && days > 0 ? Math.floor(days) : null;
+    upsertGuildSetting(guildId, 'memory_retention_days', value);
+    getCacheEntry(guildId).memoryRetentionDays = value;
+    return value;
+}
+
+/**
  * Gets the personality directive for a guild
  * @param {string} guildId - The Discord guild ID
  * @returns {Promise<string|null>} - The personality directive or null if not set
@@ -417,6 +455,8 @@ module.exports = {
     setProactiveMode,
     getGuildAI,
     setGuildAI,
+    getMemoryRetentionDays,
+    setMemoryRetentionDays,
     getPersonalityDirective,
     setPersonalityDirective,
     getDynamicResponse,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements the "Now" phase of `documentation/differentiation_strategy.md` (items #1 and #2, minus Server Wrapped): exposing server memory as a product and making "private and self-hosted" provable.

## New commands

- **`/recall <question>`** — "ask the server anything": semantic search over the guild's long-term memory, filtered by the asking user's channel visibility, answered by the AI grounded only in retrieved memories, with source snippets. Usage is counted (`command_log`) and surfaced in `/usage` (baseline metric: /recall WAU).
- **`/what-do-you-know-about-me`** — ephemeral transparency report: facts, memory counts, pending follow-ups, nickname, preferences, chat-history totals, usage rows.
- **`/forget-me`** — button-confirmed, bot-wide, single-transaction erasure implementing the exact deletion scope from the strategy doc:
  - Deletes: memories by `authorId`, USER-subject facts, follow-ups by the user, conversation history (messages/conversations/prompts), nicknames, preferences, users row.
  - Anonymizes: `usage_log`/`command_log` (userId nulled, token counts kept).
  - Review pass ("the hard 10%"): GUILD-subject facts, conversation summaries, and follow-up notes are scanned for the user's known names (word-boundary matching; "rob" doesn't match "problem") and matches deleted.
  - Ends with a post-erasure audit proving zero user-attributed rows remain.
- **`/privacy`** (Manage Server) — `retention days:<n>` auto-purges old memories (immediately + nightly via the consolidation run); `exclude`/`include channel` manage per-channel memory scope (excluding also purges already-stored memories from that channel; `remember()` refuses excluded channels before embedding).

## Schema / infrastructure

- New tables `command_log` and `memory_channel_exclusions`; new column `guild_settings.memory_retention_days` added via `applyColumnMigrations` (migration verified against an old-schema DB).
- New `services/privacyService.js`; extensions to `memoryService`, `usageTracker`, `guildSettings`.

## Test runner fixed

- First real Jest specs: `tests/privacyService.test.js`, `tests/memoryPrivacy.test.js` (13 tests, throwaway SQLite via `GOOBSTER_DB_PATH`). `npm test` now exits 0 (previously failed with "No tests found").

## Docs

- Standards doc (new Privacy controls section), `commands.md`, README, `/help`, changelog, AGENTS.md test caveat, and strategy-doc roadmap status updated.

## Verification

- ✅ `npm test` — 13/13 pass
- ✅ Smoke-require of all touched modules + fresh-DB schema apply + old-DB column migration
- ✅ **Live end-to-end demo in the real test guild** (bot connected as Goobster#5976, commands deployed via `npm run deploy-commands`, real OpenAI embeddings + chat, real Discord message delivery confirmed by fetching channel history):
  - `/recall` correctly answered "what did we decide about the minecraft server?" from seeded memories, citing Rob's and Alice's messages as sources
  - `/what-do-you-know-about-me` reported all seeded facts/memories/follow-ups/nickname/preferences
  - `/privacy` status → retention 90 days → exclude channel (purged 4 stored memories, `remember()` then refused new writes) → include
  - `/forget-me` confirm-button flow erased everything; post-erasure audit: zero rows attributed to the demo user across all 8 tables

Full transcript: [live_discord_demo_recall_privacy.log](https://cursor.com/agents/bc-12df4fda-52c5-4591-9d10-3ea3b1f33a39/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flive_discord_demo_recall_privacy.log) and delivery proof: [discord_channel_history_proof.log](https://cursor.com/agents/bc-12df4fda-52c5-4591-9d10-3ea3b1f33a39/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdiscord_channel_history_proof.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12df4fda-52c5-4591-9d10-3ea3b1f33a39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12df4fda-52c5-4591-9d10-3ea3b1f33a39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

