### PR TITLE
Enable search and server functions via voice chat

### DIFF
--- a/commands/chat/voicechat.js
+++ b/commands/chat/voicechat.js
@@ -78,6 +78,8 @@ module.exports = {
                 await interaction.editReply(
                     `🎙️ **Voice conversation started in ${voiceChannel.name}!**\n\n` +
                     `${modeInfo}\n` +
+                    'You can also ask me to do things by voice: search the web, remember or forget facts, ' +
+                    'change nicknames, generate images, or schedule follow-ups.\n' +
                     'Use `/voicechat stop` when you\'re done.'
                 );
             } catch (error) {

--- a/documentation/development_standards_and_project_goals.md
+++ b/documentation/development_standards_and_project_goals.md
@@ -73,6 +73,8 @@ Goobster is a self-hostable Discord bot designed to provide engaging AI chat, he
 ### Voice conversations
 - `/voicechat` runs live voice sessions: `services/voice/voiceSessionService.js` captures per-user Opus audio (silence-based end-of-utterance), transcribes via `services/transcriptionService.js` (OpenAI `gpt-4o-mini-transcribe`), generates replies through the normal `aiService` stack, and speaks them with ElevenLabs TTS.
 - One session per guild; utterances are processed sequentially so the bot never talks over itself. Requires an OpenAI key (STT) and ElevenLabs key (TTS).
+- **Voice tool calling**: voice turns run the same `aiService.chat` + `toolsRegistry` loop as text chat (up to 3 rounds per turn), so users can trigger server functions by speaking — web search (`performSearch`, plus native `opts.webSearch` on OpenAI/Gemini), `rememberFact`/`forgetFact`, `setNickname`, and (only when the session has a transcript text channel) `generateImage` and `scheduleFollowUp`. The registry exposes this subset via `toolsRegistry.getDefinitions(names)`.
+- Tools receive a synthetic interaction context built by `_buildToolContext`: guild/channel/client plus the turn's most recent speaker as `user`/`member`; `reply()`/`editReply()` output from wrapped commands is captured and appended to the tool result so the model voices real outcomes (e.g. permission denials). `playTrack` is deliberately excluded — music playback would destroy the session's own voice connection — as are `speakMessage`/`echoMessage` (redundant when every reply is already spoken).
 
 ## Core Features
 

--- a/services/voice/voiceSessionService.js
+++ b/services/voice/voiceSessionService.js
@@ -7,6 +7,7 @@ const {
 const prism = require('prism-media');
 const transcriptionService = require('../transcriptionService');
 const aiService = require('../aiService');
+const toolsRegistry = require('../../utils/toolsRegistry');
 const { getPromptWithGuildPersonality } = require('../../utils/memeMode');
 const { getBotPreferredName } = require('../../utils/guildContext');
 
@@ -40,6 +41,17 @@ const MAX_EMPTY_STREAK = 2;
 // In polite mode, a turn within this window after Goobster finished speaking
 // is treated as a follow-up addressed to him (no name needed).
 const FOLLOWUP_WINDOW_MS = 25000;
+// Max chat rounds per turn: tool calls consume rounds, the last round must
+// produce the spoken reply (mirrors the text-chat loop in chatHandler).
+const MAX_CHAT_ROUNDS = 3;
+
+// Tools exposed to the model during voice turns. Deliberately a subset of the
+// full registry: playTrack would tear down the session's own voice connection,
+// and speakMessage/echoMessage are redundant when every reply is already spoken.
+const VOICE_TOOL_NAMES = ['performSearch', 'setNickname', 'rememberFact', 'forgetFact'];
+// These tools post to / reference a text channel, so they are only offered
+// when the session has a transcript channel to deliver into.
+const TEXT_CHANNEL_TOOL_NAMES = ['generateImage', 'scheduleFollowUp'];
 
 /**
  * Build a RIFF/WAVE header for raw s16le PCM.
@@ -364,7 +376,7 @@ class VoiceSessionService {
             if (hasWords) {
                 speakerInfo.emptyStreak = 0;
                 session.speakers.set(userId, speakerInfo);
-                session.turnBuffer.push({ speakerName, text: transcript, at: Date.now() });
+                session.turnBuffer.push({ speakerName, text: transcript, at: Date.now(), userId, member });
                 console.log(`[VoiceSession] Segment (${speakerName}): ${transcript}`);
             } else {
                 markEmpty();
@@ -430,9 +442,83 @@ Answer with ONLY one word: "respond" or "silent".`,
     }
 
     /**
+     * Build the interaction-like context handed to tools during a voice turn.
+     * Tools written for slash commands expect a Discord interaction; this
+     * stands in for one, attributing the turn to its most recent speaker and
+     * capturing any reply() output (e.g. permission denials from wrapped
+     * commands) so the model can voice the real outcome.
+     * @returns {{context: object, captured: string[]}}
+     */
+    _buildToolContext(session, segments) {
+        const lastSpeaker = [...segments].reverse().find(s => s.member) || null;
+        const member = lastSpeaker?.member || null;
+        const captured = [];
+        const record = (response) => {
+            const content = typeof response === 'string' ? response : response?.content;
+            if (content) captured.push(content);
+        };
+
+        return {
+            captured,
+            context: {
+                guild: session.voiceChannel.guild,
+                guildId: session.guildId,
+                channel: session.textChannel || null,
+                channelId: session.textChannel?.id || null,
+                client: session.client,
+                user: member?.user || null,
+                member,
+                isVoiceInteraction: true,
+                deferReply: async () => {},
+                reply: record,
+                editReply: record,
+                followUp: record
+            }
+        };
+    }
+
+    /**
+     * Execute the tool calls requested by the model and append their results
+     * to the model conversation (same shape the text-chat loop uses).
+     */
+    async _executeToolCalls(session, toolCalls, messagesForModel, toolContext) {
+        for (const call of toolCalls) {
+            let fnResult;
+            try {
+                const parsedArgs = JSON.parse(call.arguments || '{}');
+                parsedArgs.interactionContext = toolContext.context;
+                toolContext.captured.length = 0;
+                fnResult = await toolsRegistry.execute(call.name, parsedArgs);
+
+                if (fnResult && typeof fnResult === 'object' && fnResult._display && fnResult._data) {
+                    fnResult = fnResult._display;
+                }
+                // Wrapped commands report their real outcome via reply();
+                // surface it so the model doesn't announce false successes.
+                if (toolContext.captured.length > 0) {
+                    fnResult = `${typeof fnResult === 'string' ? fnResult : JSON.stringify(fnResult)}\n${toolContext.captured.join('\n')}`;
+                }
+                console.log(`[VoiceSession] Tool ${call.name} executed`);
+            } catch (toolError) {
+                console.error(`[VoiceSession] Tool ${call.name} failed:`, toolError.message);
+                fnResult = `Error executing tool ${call.name}: ${toolError.message}`;
+            }
+
+            messagesForModel.push({
+                role: 'tool',
+                toolCallId: call.id,
+                name: call.name,
+                content: typeof fnResult === 'string' ? fnResult : JSON.stringify(fnResult)
+            });
+        }
+    }
+
+    /**
      * Generate and speak ONE reply for everything said during the turn.
-     * If new speech arrives while generating, the reply is discarded as
-     * stale and the new speech joins the still-unanswered buffer.
+     * The model may call server tools (web search, facts, nicknames, images,
+     * follow-ups) before producing the spoken reply. If new speech arrives
+     * while generating, the reply is discarded as stale and the new speech
+     * joins the still-unanswered buffer.
      */
     async _respondToTurn(session) {
         if (session.stopped || session.responding || session.turnBuffer.length === 0) return;
@@ -465,17 +551,48 @@ VOICE CONVERSATION MODE:
 You are in a live voice conversation in the Discord voice channel "${session.voiceChannel.name}". Your reply will be spoken aloud with text-to-speech.
 - The user's turn may contain several sentences or speakers; respond to the whole thought, not just the last sentence.
 - Keep replies short and conversational (1-3 sentences unless asked for detail).
-- No markdown, emojis, bullet points, links, or code - plain speakable text only.`;
+- No markdown, emojis, bullet points, links, or code - plain speakable text only.
+- You can take actions: search the web for current information, remember or forget facts about people${session.textChannel ? ', generate images (posted to the text channel), schedule follow-ups' : ''}, and change nicknames. When someone asks you to look something up or do something, use the matching tool, then tell them the outcome out loud in plain speakable words - never read out URLs, lists, or raw results.`;
 
-            const reply = await aiService.chatText([
+            const toolNames = session.textChannel
+                ? [...VOICE_TOOL_NAMES, ...TEXT_CHANNEL_TOOL_NAMES]
+                : VOICE_TOOL_NAMES;
+            const functionDefs = toolsRegistry.getDefinitions(toolNames);
+            const toolContext = this._buildToolContext(session, session.turnBuffer.slice(0, snapshotLength));
+
+            const messagesForModel = [
                 { role: 'system', content: systemPrompt },
                 ...session.history,
                 { role: 'user', content: turnText }
-            ], {
-                preset: 'chat',
-                max_tokens: 220,
-                usageContext: { guildId: session.guildId }
-            });
+            ];
+
+            let reply = null;
+            for (let round = 0; round < MAX_CHAT_ROUNDS; round++) {
+                const chatOptions = {
+                    preset: 'chat',
+                    max_tokens: 220,
+                    usageContext: { guildId: session.guildId }
+                };
+                if (functionDefs.length > 0) {
+                    chatOptions.functions = functionDefs;
+                }
+                // Providers with native web search can also answer live
+                // questions without the performSearch round-trip.
+                if (aiService.supportsNativeWebSearch()) {
+                    chatOptions.webSearch = true;
+                }
+
+                const { content, toolCalls } = await aiService.chat(messagesForModel, chatOptions);
+
+                if (toolCalls && toolCalls.length > 0 && round < MAX_CHAT_ROUNDS - 1) {
+                    messagesForModel.push({ role: 'assistant', content, toolCalls });
+                    await this._executeToolCalls(session, toolCalls, messagesForModel, toolContext);
+                    continue; // next round voices the outcome
+                }
+
+                reply = content || '';
+                break;
+            }
 
             // Staleness check: did anyone say actual words while we were thinking?
             const grewStale = session.turnBuffer.length !== snapshotLength || this._blockingCaptures(session) > 0;

--- a/tests/voiceToolCalls.test.js
+++ b/tests/voiceToolCalls.test.js
@@ -1,0 +1,225 @@
+/**
+ * Voice tool calling (services/voice/voiceSessionService.js): a spoken turn
+ * runs the same aiService.chat + toolsRegistry loop as text chat, so users
+ * can trigger web searches and other server functions from a voice channel.
+ */
+const path = require('node:path');
+const os = require('node:os');
+const fs = require('node:fs');
+
+const TEST_DB = path.join(os.tmpdir(), `goobster-voice-tools-test-${process.pid}.sqlite`);
+process.env.GOOBSTER_DB_PATH = TEST_DB;
+
+jest.mock('../services/aiService', () => ({
+    chat: jest.fn(),
+    generateText: jest.fn(),
+    supportsNativeWebSearch: jest.fn().mockReturnValue(false)
+}));
+
+jest.mock('../services/perplexityService', () => ({
+    isConfigured: jest.fn().mockReturnValue(true),
+    search: jest.fn().mockResolvedValue('Sunny, 24 degrees in Tokyo today.')
+}));
+
+jest.mock('../utils/memeMode', () => ({
+    getPromptWithGuildPersonality: jest.fn().mockResolvedValue('You are Goobster.')
+}));
+
+// These wrapped commands hard-require the gitignored config.json at load
+// time; the voice loop only needs their tool definitions to exist.
+jest.mock('../commands/music/playtrack', () => ({ execute: jest.fn() }));
+jest.mock('../commands/chat/speak', () => ({ execute: jest.fn() }));
+
+const aiService = require('../services/aiService');
+const perplexityService = require('../services/perplexityService');
+const toolsRegistry = require('../utils/toolsRegistry');
+const voiceSessionService = require('../services/voice/voiceSessionService');
+const db = require('../db');
+
+const GUILD_ID = '500000000000000001';
+const USER_ID = '500000000000000002';
+
+function makeMember() {
+    return {
+        user: { id: USER_ID, username: 'rob', bot: false },
+        displayName: 'Rob'
+    };
+}
+
+function makeSession({ textChannel = { id: '500000000000000003', send: jest.fn().mockResolvedValue(undefined) } } = {}) {
+    return {
+        guildId: GUILD_ID,
+        voiceChannel: { name: 'General', guild: { id: GUILD_ID } },
+        textChannel,
+        connection: {},
+        ttsService: { textToSpeech: jest.fn().mockResolvedValue(undefined) },
+        client: { user: { id: 'bot', username: 'Goobster' } },
+        mode: 'open',
+        lastBotSpokeAt: 0,
+        botNames: ['goobster'],
+        history: [],
+        turnBuffer: [{
+            speakerName: 'Rob',
+            text: 'Hey Goobster, search the web for the weather in Tokyo',
+            at: Date.now(),
+            userId: USER_ID,
+            member: makeMember()
+        }],
+        turnTimer: null,
+        responding: false,
+        staleDiscards: 0,
+        activeCaptures: new Set(),
+        speakers: new Map(),
+        stopped: false
+    };
+}
+
+afterAll(async () => {
+    await db.closeConnection();
+    for (const suffix of ['', '-wal', '-shm']) {
+        fs.rmSync(TEST_DB + suffix, { force: true });
+    }
+});
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    aiService.supportsNativeWebSearch.mockReturnValue(false);
+});
+
+describe('voice turn tool calling', () => {
+    test('executes a performSearch tool call and speaks the outcome', async () => {
+        aiService.chat
+            .mockResolvedValueOnce({
+                content: '',
+                toolCalls: [{ id: 'call-1', name: 'performSearch', arguments: '{"query":"weather in Tokyo"}' }]
+            })
+            .mockResolvedValueOnce({ content: 'It is sunny and 24 degrees in Tokyo right now.', toolCalls: [] });
+
+        const session = makeSession();
+        await voiceSessionService._respondToTurn(session);
+
+        expect(perplexityService.search).toHaveBeenCalledWith('weather in Tokyo');
+        expect(aiService.chat).toHaveBeenCalledTimes(2);
+
+        // First round offers the voice tool subset
+        const firstOpts = aiService.chat.mock.calls[0][1];
+        const offered = firstOpts.functions.map(f => f.name);
+        expect(offered).toEqual(expect.arrayContaining(['performSearch', 'rememberFact', 'forgetFact', 'setNickname', 'generateImage', 'scheduleFollowUp']));
+        expect(offered).not.toContain('playTrack');
+        expect(offered).not.toContain('speakMessage');
+
+        // Second round sees the tool result
+        const secondMessages = aiService.chat.mock.calls[1][0];
+        const toolMessage = secondMessages.find(m => m.role === 'tool');
+        expect(toolMessage).toMatchObject({
+            toolCallId: 'call-1',
+            name: 'performSearch',
+            content: 'Sunny, 24 degrees in Tokyo today.'
+        });
+
+        // The final reply is spoken and recorded in history
+        expect(session.ttsService.textToSpeech).toHaveBeenCalledWith(
+            'It is sunny and 24 degrees in Tokyo right now.',
+            session.voiceChannel,
+            session.connection
+        );
+        expect(session.history.at(-1)).toEqual({
+            role: 'assistant',
+            content: 'It is sunny and 24 degrees in Tokyo right now.'
+        });
+        expect(session.turnBuffer).toHaveLength(0);
+    });
+
+    test('tools receive a voice interaction context attributed to the speaker', async () => {
+        const executeSpy = jest.spyOn(toolsRegistry, 'execute');
+        aiService.chat
+            .mockResolvedValueOnce({
+                content: '',
+                toolCalls: [{ id: 'call-2', name: 'performSearch', arguments: '{"query":"latest node lts"}' }]
+            })
+            .mockResolvedValueOnce({ content: 'Done.', toolCalls: [] });
+
+        const session = makeSession();
+        await voiceSessionService._respondToTurn(session);
+
+        const [name, args] = executeSpy.mock.calls[0];
+        expect(name).toBe('performSearch');
+        expect(args.interactionContext).toMatchObject({
+            guildId: GUILD_ID,
+            channelId: session.textChannel.id,
+            isVoiceInteraction: true
+        });
+        expect(args.interactionContext.user.id).toBe(USER_ID);
+        expect(args.interactionContext.member.displayName).toBe('Rob');
+        executeSpy.mockRestore();
+    });
+
+    test('text-channel tools are withheld when the session has no transcript channel', async () => {
+        aiService.chat.mockResolvedValueOnce({ content: 'Just chatting.', toolCalls: [] });
+
+        const session = makeSession({ textChannel: null });
+        await voiceSessionService._respondToTurn(session);
+
+        const offered = aiService.chat.mock.calls[0][1].functions.map(f => f.name);
+        expect(offered).toEqual(expect.arrayContaining(['performSearch', 'rememberFact', 'forgetFact', 'setNickname']));
+        expect(offered).not.toContain('generateImage');
+        expect(offered).not.toContain('scheduleFollowUp');
+    });
+
+    test('a failing tool surfaces the error to the model instead of crashing the turn', async () => {
+        perplexityService.search.mockRejectedValueOnce(new Error('Perplexity is down'));
+        aiService.chat
+            .mockResolvedValueOnce({
+                content: '',
+                toolCalls: [{ id: 'call-3', name: 'performSearch', arguments: '{"query":"anything"}' }]
+            })
+            .mockResolvedValueOnce({ content: 'Sorry, my search is not working right now.', toolCalls: [] });
+
+        const session = makeSession();
+        await voiceSessionService._respondToTurn(session);
+
+        const secondMessages = aiService.chat.mock.calls[1][0];
+        const toolMessage = secondMessages.find(m => m.role === 'tool');
+        expect(toolMessage.content).toContain('Error executing tool performSearch');
+        expect(toolMessage.content).toContain('Perplexity is down');
+        expect(session.ttsService.textToSpeech).toHaveBeenCalledWith(
+            'Sorry, my search is not working right now.',
+            session.voiceChannel,
+            session.connection
+        );
+    });
+
+    test('plain conversational turns still work without any tool call', async () => {
+        aiService.chat.mockResolvedValueOnce({ content: 'Hey Rob, not much, just vibing.', toolCalls: [] });
+
+        const session = makeSession();
+        session.turnBuffer[0].text = 'Hey Goobster, what is up?';
+        await voiceSessionService._respondToTurn(session);
+
+        expect(aiService.chat).toHaveBeenCalledTimes(1);
+        expect(session.ttsService.textToSpeech).toHaveBeenCalledWith(
+            'Hey Rob, not much, just vibing.',
+            session.voiceChannel,
+            session.connection
+        );
+    });
+
+    test('the tool loop is capped: the last round must produce the spoken reply', async () => {
+        aiService.chat.mockResolvedValue({
+            content: 'fallback text',
+            toolCalls: [{ id: 'loop', name: 'performSearch', arguments: '{"query":"again"}' }]
+        });
+
+        const session = makeSession();
+        await voiceSessionService._respondToTurn(session);
+
+        // 3 rounds max: two tool rounds, then the final round's content is used
+        expect(aiService.chat).toHaveBeenCalledTimes(3);
+        expect(perplexityService.search).toHaveBeenCalledTimes(2);
+        expect(session.ttsService.textToSpeech).toHaveBeenCalledWith(
+            'fallback text',
+            session.voiceChannel,
+            session.connection
+        );
+    });
+});

--- a/utils/toolsRegistry.js
+++ b/utils/toolsRegistry.js
@@ -703,9 +703,15 @@ function getCommandResponse(sub, track, playlistName) {
 module.exports = {
     /**
      * Return array of OpenAI function definitions.
+     * @param {string[]} [names] - optional allowlist; when provided, only
+     *   definitions for these tool names are returned (e.g. the voice-safe
+     *   subset used by live voice sessions).
      */
-    getDefinitions() {
-        return Object.values(tools).map(t => t.definition);
+    getDefinitions(names) {
+        const definitions = Object.values(tools).map(t => t.definition);
+        if (!Array.isArray(names)) return definitions;
+        const allowed = new Set(names);
+        return definitions.filter(def => allowed.has(def.name));
     },
 
     /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Voice conversation turns now run the same `aiService.chat` + `toolsRegistry` tool-calling loop as text chat, so users can ask Goobster to execute searches and other server functions by speaking in a `/voicechat` session.

### What changed

- `services/voice/voiceSessionService.js`
  - `_respondToTurn` replaces the plain `chatText` call with a capped tool loop (up to 3 rounds, mirroring `chatHandler`): the model can call tools, results are fed back as `role: 'tool'` messages, and the final round produces the spoken reply.
  - Voice tool subset: `performSearch` (Perplexity), `rememberFact`/`forgetFact`, `setNickname`, plus `generateImage` and `scheduleFollowUp` only when the session has a transcript text channel to deliver into. `playTrack` is deliberately excluded (music playback would destroy the session's own voice connection); `speakMessage`/`echoMessage` are redundant when every reply is already spoken.
  - Native web search (`opts.webSearch`) is enabled when the provider supports it (OpenAI/Gemini), matching text chat.
  - `_buildToolContext` builds a synthetic interaction context for tools: guild/channel/client plus the turn's most recent speaker as `user`/`member`. `reply()`/`editReply()` output from wrapped commands is captured and appended to the tool result so the model voices real outcomes (e.g. permission denials from `/nickname bot set`).
  - Turn buffer segments now carry `userId`/`member` for speaker attribution.
- `utils/toolsRegistry.js`: `getDefinitions(names)` accepts an optional allowlist.
- `commands/chat/voicechat.js`: start message mentions the new voice capabilities.
- `documentation/development_standards_and_project_goals.md`: voice section updated.

### Testing

- New Jest spec `tests/voiceToolCalls.test.js` (6 tests): tool execution + spoken outcome, speaker-attributed tool context, transcript-channel gating, tool-error surfacing, plain conversational turns, and the round cap.
- `npm run lint`, `npm run smoke` (107 modules), and `npm test` (11 suites, 91 tests) all pass.
- Live end-to-end verification with a real Discord connection, real OpenAI tool calling, real Perplexity search, and real ElevenLabs TTS in a voice channel (see agent walkthrough).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f76e7-d202-7943-8151-ce96058345a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f76e7-d202-7943-8151-ce96058345a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

