### PR TITLE
Fix panel TTS voice setting: validate against the ElevenLabs voice library

### DIFF
--- a/commands/voice/setvoice.js
+++ b/commands/voice/setvoice.js
@@ -17,38 +17,55 @@ module.exports = {
     ),
 
   async execute(interaction) {
-    const newVoiceId = interaction.options.getString('voice_id');
+    const requestedVoice = interaction.options.getString('voice_id');
+
+    if (!voiceService?.tts) {
+      await interaction.reply({
+        content: '❌ ElevenLabs TTS is not configured (set `ELEVENLABS_API_KEY`).',
+        ephemeral: true
+      });
+      return;
+    }
+
+    await interaction.deferReply({ ephemeral: true });
+
+    // 1. Resolve the name/ID against the account's voice library so typos
+    //    and unavailable voices fail here, not at speak time.
+    let resolved;
+    try {
+      resolved = await voiceService.tts.resolveVoice(requestedVoice);
+    } catch (error) {
+      await interaction.editReply(`❌ ${error.message}`);
+      return;
+    }
 
     try {
-      // 1. Persist change to config.json
+      // 2. Persist the resolved ID (+ display name) to config.json
       const raw = fs.readFileSync(CONFIG_PATH, 'utf-8');
       const config = JSON.parse(raw);
 
       if (!config.elevenlabs) {
         config.elevenlabs = {};
       }
-      config.elevenlabs.voiceId = newVoiceId;
+      config.elevenlabs.voiceId = resolved.id;
+      config.elevenlabs.voiceName = resolved.name;
 
       fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2));
 
-      // 2. Update the running voice service (if ElevenLabs is enabled)
-      if (voiceService && voiceService.tts) {
-        voiceService.tts.voiceId = newVoiceId;
-        if (voiceService.config && voiceService.config.elevenlabs) {
-          voiceService.config.elevenlabs.voiceId = newVoiceId;
-        }
+      // 3. Update the running voice service
+      voiceService.tts.voiceId = resolved.id;
+      voiceService.tts.voiceName = resolved.name;
+      if (voiceService.config && voiceService.config.elevenlabs) {
+        voiceService.config.elevenlabs.voiceId = resolved.id;
+        voiceService.config.elevenlabs.voiceName = resolved.name;
       }
 
-      await interaction.reply({
-        content: `✅ ElevenLabs voice ID has been updated globally to \`${newVoiceId}\`. This will take effect immediately for all new TTS requests.`,
-        ephemeral: true
-      });
+      await interaction.editReply(
+        `✅ ElevenLabs voice has been updated globally to **${resolved.name || resolved.id}** (\`${resolved.id}\`). This will take effect immediately for all new TTS requests.`
+      );
     } catch (error) {
       console.error('Failed to update ElevenLabs voice ID:', error);
-      await interaction.reply({
-        content: '❌ Failed to update the ElevenLabs voice ID. Please check the logs and try again.',
-        ephemeral: true
-      });
+      await interaction.editReply('❌ Failed to update the ElevenLabs voice ID. Please check the logs and try again.');
     }
   }
 };

--- a/services/panelService.js
+++ b/services/panelService.js
@@ -611,6 +611,7 @@ function createPanelService({ client, voiceService, logger = console, deps = {} 
                 },
                 global: {
                     ttsVoiceId: voiceService?.tts?.voiceId ?? null,
+                    ttsVoiceName: voiceService?.tts?.voiceName ?? null,
                     ttsAvailable: Boolean(voiceService?.tts)
                 }
             };
@@ -776,31 +777,60 @@ function createPanelService({ client, voiceService, logger = console, deps = {} 
         },
 
         /**
-         * Set the global ElevenLabs TTS voice, mirroring /setvoice: persist
-         * to config.json and update the live TTS service.
+         * The account's ElevenLabs voice library, for the panel's voice picker.
+         * @returns {Promise<Array<{id: string, name: string, category: string|null}>>}
          */
-        setTtsVoice(voiceId) {
+        async listTtsVoices() {
+            if (!voiceService?.tts) {
+                throw new PanelError(503, 'TTS_UNAVAILABLE', 'ElevenLabs TTS is not configured.');
+            }
+            try {
+                return await voiceService.tts.listVoices();
+            } catch (error) {
+                throw new PanelError(502, 'TTS_VOICES_FAILED', `Could not fetch the voice library: ${error.message}`, {}, { cause: error });
+            }
+        },
+
+        /**
+         * Set the global ElevenLabs TTS voice, mirroring /setvoice. The value
+         * is resolved against the account's voice library first (names are
+         * matched case-insensitively, tolerating display suffixes), so typos
+         * fail here with a clear error instead of breaking TTS at speak time.
+         * The resolved voice ID (not the raw input) is persisted to
+         * config.json and applied to the live TTS service.
+         */
+        async setTtsVoice(voiceId) {
             if (!voiceService?.tts) {
                 throw new PanelError(503, 'TTS_UNAVAILABLE', 'ElevenLabs TTS is not configured.');
             }
             if (typeof voiceId !== 'string' || !VOICE_ID_RE.test(voiceId.trim())) {
                 throw new PanelError(400, 'BAD_REQUEST', 'voiceId must be a short name or ID (letters, digits, spaces, dashes).');
             }
-            const value = voiceId.trim();
+
+            let resolved;
+            try {
+                resolved = await voiceService.tts.resolveVoice(voiceId.trim());
+            } catch (error) {
+                throw new PanelError(400, 'VOICE_NOT_FOUND', error.message, {}, { cause: error });
+            }
+
             try {
                 const raw = fs.readFileSync(configPath, 'utf-8');
                 const parsedConfig = JSON.parse(raw);
                 if (!parsedConfig.elevenlabs) parsedConfig.elevenlabs = {};
-                parsedConfig.elevenlabs.voiceId = value;
+                parsedConfig.elevenlabs.voiceId = resolved.id;
+                parsedConfig.elevenlabs.voiceName = resolved.name;
                 fs.writeFileSync(configPath, JSON.stringify(parsedConfig, null, 2));
             } catch (error) {
                 throw new PanelError(500, 'CONFIG_WRITE_FAILED', `Could not persist the voice ID: ${error.message}`, {}, { cause: error });
             }
-            voiceService.tts.voiceId = value;
+            voiceService.tts.voiceId = resolved.id;
+            voiceService.tts.voiceName = resolved.name;
             if (voiceService.config?.elevenlabs) {
-                voiceService.config.elevenlabs.voiceId = value;
+                voiceService.config.elevenlabs.voiceId = resolved.id;
+                voiceService.config.elevenlabs.voiceName = resolved.name;
             }
-            return { voiceId: value };
+            return { voiceId: resolved.id, voiceName: resolved.name };
         }
     };
 }

--- a/services/panelService.js
+++ b/services/panelService.js
@@ -23,7 +23,10 @@ const QUEUE_PREVIEW_LIMIT = 25;
 const DIRECTIVE_MAX_LENGTH = 2000;
 const NICKNAME_MAX_LENGTH = 32;
 const RETENTION_MAX_DAYS = 3650;
-const VOICE_ID_RE = /^[a-zA-Z0-9 _-]{1,80}$/;
+// Sanity check only - real validation is the voice-library lookup in
+// setTtsVoice. Display names may carry punctuation ("Sarah - Mature,
+// Reassuring, Confident", "Herbie (Old Man ...)"), so allow it.
+const VOICE_ID_RE = /^[\p{L}\p{N} ,.&()'_-]{1,100}$/u;
 
 /** Error carrying an HTTP status + machine-readable code for the panel API. */
 class PanelError extends Error {
@@ -804,7 +807,7 @@ function createPanelService({ client, voiceService, logger = console, deps = {} 
                 throw new PanelError(503, 'TTS_UNAVAILABLE', 'ElevenLabs TTS is not configured.');
             }
             if (typeof voiceId !== 'string' || !VOICE_ID_RE.test(voiceId.trim())) {
-                throw new PanelError(400, 'BAD_REQUEST', 'voiceId must be a short name or ID (letters, digits, spaces, dashes).');
+                throw new PanelError(400, 'BAD_REQUEST', 'voiceId must be a voice name or ID (letters, digits, spaces, and basic punctuation).');
             }
 
             let resolved;

--- a/services/voice/elevenLabsTTSService.js
+++ b/services/voice/elevenLabsTTSService.js
@@ -115,11 +115,39 @@ class ElevenLabsTTSService extends EventEmitter {
     }
 
     /**
-     * Resolve a voice name or ID to a { id, name } pair against the account's
-     * voice library. Matching is case-insensitive and tolerant of the display
-     * suffixes ElevenLabs appends to premade voices ("Sarah" matches
-     * "Sarah - Mature, Reassuring, Confident"). Throws (listing the available
-     * names) when nothing matches.
+     * Look up a single voice by its exact ID via GET /v1/voices/{id}. Works
+     * for voices beyond the account's own library (e.g. premade voices not
+     * shown by /v1/voices).
+     * @returns {Promise<{id: string, name: string, category: string|null}|null>}
+     *   null when ElevenLabs reports the voice does not exist
+     */
+    async getVoiceInfo(voiceId) {
+        const res = await fetch(`https://api.elevenlabs.io/v1/voices/${encodeURIComponent(voiceId)}`, {
+            headers: { 'xi-api-key': this.apiKey }
+        });
+        if (res.ok) {
+            const data = await res.json();
+            return { id: data.voice_id || voiceId, name: data.name || null, category: data.category || null };
+        }
+        let detail = null;
+        try {
+            const body = await res.json();
+            detail = typeof body.detail === 'string' ? body.detail : body.detail?.status;
+        } catch { /* non-JSON error body */ }
+        if (res.status === 400 || res.status === 404 || detail === 'voice_not_found') {
+            return null;
+        }
+        throw new Error(`ElevenLabs voices API error ${res.status}`);
+    }
+
+    /**
+     * Resolve a voice name or ID to a { id, name } pair. Names are matched
+     * against the account's voice library, case-insensitively and tolerant of
+     * the display suffixes ElevenLabs appends to premade voices ("Sarah"
+     * matches "Sarah - Mature, Reassuring, Confident"). Manually supplied
+     * voice IDs are looked up individually so their real name and category
+     * are inherited even when the voice isn't in the library list. Throws
+     * when nothing matches (listing the available names for name queries).
      */
     async resolveVoice(nameOrId) {
         const query = String(nameOrId || '').trim();
@@ -132,9 +160,11 @@ class ElevenLabsTTSService extends EventEmitter {
         if (VOICE_ID_PATTERN.test(query)) {
             const byId = voices.find(v => v.id === query);
             if (byId) return { id: byId.id, name: byId.name };
-            // IDs of voices not in the library (e.g. premade defaults) still
-            // work with the TTS endpoint, so let them through unnamed.
-            return { id: query, name: null };
+            // Manual ID outside the library list: inherit its info from the
+            // per-voice endpoint, or fail clearly when it doesn't exist.
+            const info = await this.getVoiceInfo(query);
+            if (info) return { id: info.id, name: info.name };
+            throw new Error(`ElevenLabs voice ID "${nameOrId}" does not exist (or your account cannot access it)`);
         }
 
         const key = query.toLowerCase();

--- a/services/voice/elevenLabsTTSService.js
+++ b/services/voice/elevenLabsTTSService.js
@@ -28,11 +28,13 @@ class ElevenLabsTTSService extends EventEmitter {
         this.voiceId = config.elevenlabs?.voiceId
             || process.env.ELEVENLABS_VOICE_ID
             || DEFAULT_VOICE_ID;
+        // Friendly display name for the configured voice (when known)
+        this.voiceName = config.elevenlabs?.voiceName || null;
         this.modelId = config.elevenlabs?.modelId
             || process.env.ELEVENLABS_MODEL_ID
             || DEFAULT_MODEL_ID;
 
-        this.voiceNameCache = new Map(); // lowercased name -> voice ID
+        this.voiceNameCache = new Map(); // lowercased name -> { id, name, category }
 
         this.player = createAudioPlayer({
             behaviors: { noSubscriber: NoSubscriberBehavior.Pause }
@@ -89,19 +91,10 @@ class ElevenLabsTTSService extends EventEmitter {
     }
 
     /**
-     * Resolve a voice name (e.g. "Rachel") to its voice ID via the ElevenLabs
-     * voices API. Values that already look like voice IDs pass through as-is.
+     * Fetch the account's voice library: [{ id, name, category }].
+     * Results also refresh the name-resolution cache.
      */
-    async resolveVoiceId(nameOrId) {
-        if (!nameOrId || VOICE_ID_PATTERN.test(nameOrId)) {
-            return nameOrId || DEFAULT_VOICE_ID;
-        }
-
-        const key = nameOrId.toLowerCase();
-        if (this.voiceNameCache.has(key)) {
-            return this.voiceNameCache.get(key);
-        }
-
+    async listVoices() {
         const res = await fetch('https://api.elevenlabs.io/v1/voices', {
             headers: { 'xi-api-key': this.apiKey }
         });
@@ -109,19 +102,87 @@ class ElevenLabsTTSService extends EventEmitter {
             throw new Error(`ElevenLabs voices API error ${res.status}`);
         }
         const data = await res.json();
-        for (const voice of data.voices || []) {
-            this.voiceNameCache.set(voice.name.toLowerCase(), voice.voice_id);
+        const voices = (data.voices || []).map(v => ({
+            id: v.voice_id,
+            name: v.name,
+            category: v.category || null
+        }));
+        this.voiceNameCache.clear();
+        for (const voice of voices) {
+            this.voiceNameCache.set(voice.name.toLowerCase(), voice);
+        }
+        return voices;
+    }
+
+    /**
+     * Resolve a voice name or ID to a { id, name } pair against the account's
+     * voice library. Matching is case-insensitive and tolerant of the display
+     * suffixes ElevenLabs appends to premade voices ("Sarah" matches
+     * "Sarah - Mature, Reassuring, Confident"). Throws (listing the available
+     * names) when nothing matches.
+     */
+    async resolveVoice(nameOrId) {
+        const query = String(nameOrId || '').trim();
+        if (!query) {
+            return { id: DEFAULT_VOICE_ID, name: null };
         }
 
-        const resolved = this.voiceNameCache.get(key);
-        if (!resolved) {
-            throw new Error(`ElevenLabs voice "${nameOrId}" not found in your voice library`);
+        const voices = await this.listVoices();
+
+        if (VOICE_ID_PATTERN.test(query)) {
+            const byId = voices.find(v => v.id === query);
+            if (byId) return { id: byId.id, name: byId.name };
+            // IDs of voices not in the library (e.g. premade defaults) still
+            // work with the TTS endpoint, so let them through unnamed.
+            return { id: query, name: null };
         }
-        return resolved;
+
+        const key = query.toLowerCase();
+        const exact = voices.find(v => v.name.toLowerCase() === key);
+        if (exact) return { id: exact.id, name: exact.name };
+
+        // Prefix match on the base name before any " - description" suffix
+        const prefix = voices.filter(v => {
+            const base = v.name.toLowerCase().split(/\s+-\s+/)[0].trim();
+            return base === key || v.name.toLowerCase().startsWith(key);
+        });
+        if (prefix.length === 1) {
+            // Cache the alias so per-request resolution stays off the network
+            this.voiceNameCache.set(key, prefix[0]);
+            return { id: prefix[0].id, name: prefix[0].name };
+        }
+        if (prefix.length > 1) {
+            throw new Error(`ElevenLabs voice "${nameOrId}" is ambiguous: ${prefix.map(v => v.name).join(', ')}`);
+        }
+
+        const available = voices.map(v => v.name).slice(0, 25).join(', ');
+        throw new Error(`ElevenLabs voice "${nameOrId}" not found in your voice library. Available: ${available}`);
+    }
+
+    /**
+     * Resolve to just the voice ID, using the name cache to avoid a network
+     * round trip on every TTS request. IDs pass through as-is.
+     */
+    async resolveVoiceId(nameOrId) {
+        if (!nameOrId || VOICE_ID_PATTERN.test(nameOrId)) {
+            return nameOrId || DEFAULT_VOICE_ID;
+        }
+        const cached = this.voiceNameCache.get(String(nameOrId).trim().toLowerCase());
+        if (cached) return cached.id;
+        const { id } = await this.resolveVoice(nameOrId);
+        return id;
     }
 
     async fetchStream(text) {
-        const voiceId = await this.resolveVoiceId(this.voiceId);
+        // A stale/misspelled configured voice must not silence TTS entirely:
+        // fall back to the default voice and keep speaking.
+        let voiceId;
+        try {
+            voiceId = await this.resolveVoiceId(this.voiceId);
+        } catch (error) {
+            console.warn(`[TTS] Configured voice "${this.voiceId}" could not be resolved (${error.message}); falling back to the default voice`);
+            voiceId = DEFAULT_VOICE_ID;
+        }
         // MP3 streaming endpoint – available on all plans (PCM requires Pro+)
         const url =
             `https://api.elevenlabs.io/v1/text-to-speech/${voiceId}/stream` +

--- a/tests/elevenLabsVoiceResolution.test.js
+++ b/tests/elevenLabsVoiceResolution.test.js
@@ -63,18 +63,40 @@ describe('resolveVoice', () => {
         await expect(service.resolveVoice('Brian')).rejects.toThrow(/ambiguous/);
     });
 
-    test('resolves library IDs to their names and passes unknown IDs through', async () => {
+    test('resolves library IDs to their names without extra lookups', async () => {
         fetch.mockResolvedValue(mockVoicesResponse());
         const service = makeService();
         await expect(service.resolveVoice('pMsXgVXv3BLzUgSXRplE')).resolves.toEqual({
             id: 'pMsXgVXv3BLzUgSXRplE',
             name: 'Serena'
         });
-        // e.g. a premade voice not shown in the library still works with TTS
+        expect(fetch).toHaveBeenCalledTimes(1); // just the library list
+    });
+
+    test('manual IDs outside the library inherit their info from the per-voice endpoint', async () => {
+        fetch.mockImplementation(async (url) => {
+            const u = String(url);
+            if (u.endsWith('/v1/voices')) return mockVoicesResponse();
+            if (u.includes(`/v1/voices/${DEFAULT_VOICE_ID}`)) {
+                return {
+                    ok: true,
+                    json: async () => ({ voice_id: DEFAULT_VOICE_ID, name: 'Janet', category: 'professional' })
+                };
+            }
+            return { ok: false, status: 400, json: async () => ({ detail: 'voice_not_found' }) };
+        });
+        const service = makeService();
+
+        // Accessible ID not in the library list: name/category are inherited
         await expect(service.resolveVoice(DEFAULT_VOICE_ID)).resolves.toEqual({
             id: DEFAULT_VOICE_ID,
-            name: null
+            name: 'Janet'
         });
+
+        // Nonexistent ID: rejected at save time with a clear error
+        await expect(service.resolveVoice('zzzzzzzzzzzzzzzzzzzz')).rejects.toThrow(
+            /voice ID "zzzzzzzzzzzzzzzzzzzz" does not exist/
+        );
     });
 });
 

--- a/tests/elevenLabsVoiceResolution.test.js
+++ b/tests/elevenLabsVoiceResolution.test.js
@@ -1,0 +1,128 @@
+/**
+ * Unit tests for ElevenLabs voice resolution
+ * (services/voice/elevenLabsTTSService.js): name/ID lookup against the voice
+ * library, prefix matching on display names, caching, and the speak-time
+ * fallback to the default voice. node-fetch is mocked - no network.
+ */
+jest.mock('node-fetch', () => jest.fn());
+
+const fetch = require('node-fetch');
+const ElevenLabsTTSService = require('../services/voice/elevenLabsTTSService');
+
+const DEFAULT_VOICE_ID = '21m00Tcm4TlvDq8ikWAM';
+
+const LIBRARY = [
+    { voice_id: 'EXAVITQu4vr4xnSDxMaL', name: 'Sarah - Mature, Reassuring, Confident', category: 'premade' },
+    { voice_id: 'nPczCjzI2devNBz1zQrb', name: 'Brian - Deep, Resonant and Comforting', category: 'premade' },
+    { voice_id: 'AAAAAAAAAAAAAAAA0001', name: 'Brian - Deep, Resonant and Comforting', category: 'professional' },
+    { voice_id: 'pMsXgVXv3BLzUgSXRplE', name: 'Serena', category: 'premade' }
+];
+
+function mockVoicesResponse() {
+    return { ok: true, json: async () => ({ voices: LIBRARY }) };
+}
+
+function makeService() {
+    return new ElevenLabsTTSService({ elevenlabs: { apiKey: 'test-key' } });
+}
+
+beforeEach(() => {
+    fetch.mockReset();
+});
+
+describe('resolveVoice', () => {
+    test('matches an exact display name case-insensitively', async () => {
+        fetch.mockResolvedValueOnce(mockVoicesResponse());
+        const service = makeService();
+        await expect(service.resolveVoice('serena')).resolves.toEqual({
+            id: 'pMsXgVXv3BLzUgSXRplE',
+            name: 'Serena'
+        });
+    });
+
+    test('matches the base name before the " - description" suffix', async () => {
+        fetch.mockResolvedValueOnce(mockVoicesResponse());
+        const service = makeService();
+        await expect(service.resolveVoice('Sarah')).resolves.toEqual({
+            id: 'EXAVITQu4vr4xnSDxMaL',
+            name: 'Sarah - Mature, Reassuring, Confident'
+        });
+    });
+
+    test('rejects unknown voices with the available names listed', async () => {
+        fetch.mockResolvedValueOnce(mockVoicesResponse());
+        const service = makeService();
+        await expect(service.resolveVoice('Rachel')).rejects.toThrow(
+            /voice "Rachel" not found .* Available: .*Sarah/
+        );
+    });
+
+    test('rejects ambiguous base names (two Brians)', async () => {
+        fetch.mockResolvedValueOnce(mockVoicesResponse());
+        const service = makeService();
+        await expect(service.resolveVoice('Brian')).rejects.toThrow(/ambiguous/);
+    });
+
+    test('resolves library IDs to their names and passes unknown IDs through', async () => {
+        fetch.mockResolvedValue(mockVoicesResponse());
+        const service = makeService();
+        await expect(service.resolveVoice('pMsXgVXv3BLzUgSXRplE')).resolves.toEqual({
+            id: 'pMsXgVXv3BLzUgSXRplE',
+            name: 'Serena'
+        });
+        // e.g. a premade voice not shown in the library still works with TTS
+        await expect(service.resolveVoice(DEFAULT_VOICE_ID)).resolves.toEqual({
+            id: DEFAULT_VOICE_ID,
+            name: null
+        });
+    });
+});
+
+describe('resolveVoiceId caching', () => {
+    test('IDs skip the network entirely; resolved names are cached', async () => {
+        fetch.mockResolvedValue(mockVoicesResponse());
+        const service = makeService();
+
+        await expect(service.resolveVoiceId('pMsXgVXv3BLzUgSXRplE')).resolves.toBe('pMsXgVXv3BLzUgSXRplE');
+        expect(fetch).not.toHaveBeenCalled();
+
+        await expect(service.resolveVoiceId('Sarah')).resolves.toBe('EXAVITQu4vr4xnSDxMaL');
+        expect(fetch).toHaveBeenCalledTimes(1);
+
+        // Second lookup of the same alias hits the cache, not the API
+        await expect(service.resolveVoiceId('Sarah')).resolves.toBe('EXAVITQu4vr4xnSDxMaL');
+        expect(fetch).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('fetchStream fallback', () => {
+    test('an unresolvable configured voice falls back to the default voice instead of failing', async () => {
+        const service = makeService();
+        service.voiceId = 'Rachel'; // not in the library
+
+        fetch.mockImplementation(async (url) => {
+            if (String(url).includes('/v1/voices')) return mockVoicesResponse();
+            return { ok: true, body: 'stream' };
+        });
+
+        const response = await service.fetchStream('hello');
+        expect(response.ok).toBe(true);
+
+        const ttsCall = fetch.mock.calls.find(([url]) => String(url).includes('/v1/text-to-speech/'));
+        expect(ttsCall[0]).toContain(`/v1/text-to-speech/${DEFAULT_VOICE_ID}/stream`);
+    });
+
+    test('a valid configured voice name is resolved and used', async () => {
+        const service = makeService();
+        service.voiceId = 'Serena';
+
+        fetch.mockImplementation(async (url) => {
+            if (String(url).includes('/v1/voices')) return mockVoicesResponse();
+            return { ok: true, body: 'stream' };
+        });
+
+        await service.fetchStream('hello');
+        const ttsCall = fetch.mock.calls.find(([url]) => String(url).includes('/v1/text-to-speech/'));
+        expect(ttsCall[0]).toContain('/v1/text-to-speech/pMsXgVXv3BLzUgSXRplE/stream');
+    });
+});

--- a/tests/panelService.test.js
+++ b/tests/panelService.test.js
@@ -537,6 +537,11 @@ describe('panelService global TTS voice', () => {
             expect(tts.voiceId).toBe('Rachel'); // unchanged
             expect(JSON.parse(fsSync.readFileSync(configPath, 'utf-8')).elevenlabs).toBeUndefined();
 
+            // Full display names (as chosen from the panel's voice picker,
+            // punctuation included) pass validation and resolve exactly
+            const picked = await service.setTtsVoice('Sarah - Mature, Reassuring, Confident');
+            expect(picked.voiceId).toBe('EXAVITQu4vr4xnSDxMaL');
+
             // Base-name matching: "sarah" resolves to the full display name
             const result = await service.setTtsVoice('sarah');
             expect(result).toEqual({

--- a/tests/panelService.test.js
+++ b/tests/panelService.test.js
@@ -484,38 +484,84 @@ describe('panelService global TTS voice', () => {
     const fsSync = require('node:fs');
     const pathMod = require('node:path');
 
-    test('persists the voice ID to config and the live service', () => {
+    function buildVoicePanel({ configPath }) {
+        const textChannel = makeTextChannel({ id: TEXT_CH, name: 'general' });
+        const guild = makeGuild({ id: GUILD_A, name: 'Alpha', channels: [textChannel] });
+        // Mirrors the real TTS service contract: resolveVoice validates
+        // against the account's voice library and returns { id, name }.
+        const library = [
+            { id: 'EXAVITQu4vr4xnSDxMaL', name: 'Sarah - Mature, Reassuring, Confident', category: 'premade' },
+            { id: 'pMsXgVXv3BLzUgSXRplE', name: 'Serena', category: 'premade' }
+        ];
+        const tts = {
+            voiceId: 'Rachel',
+            voiceName: null,
+            listVoices: jest.fn(async () => library),
+            resolveVoice: jest.fn(async (query) => {
+                const q = String(query).toLowerCase();
+                const match = library.find(v =>
+                    v.name.toLowerCase() === q || v.name.toLowerCase().split(/\s+-\s+/)[0] === q);
+                if (!match) throw new Error(`ElevenLabs voice "${query}" not found in your voice library`);
+                return { id: match.id, name: match.name };
+            })
+        };
+        const service = createPanelService({
+            client: makeClient([guild]),
+            voiceService: { musicService: makeMusicService(), tts, config: { elevenlabs: { voiceId: 'Rachel' } } },
+            logger: { warn: () => {}, error: () => {} },
+            deps: {
+                configPath,
+                voiceSessionService: { hasSession: () => false, getSession: () => null },
+                aiService: { getProvider: () => 'openai', getDefaultModel: () => 'm' },
+                memoryService: {}, memeMode: {}, guildSettings: {},
+                factsService: {}, followupService: {}, activityService: {},
+                aiConfig: { openai: { thoughtfulModel: 'gpt-5.5' } },
+                transcriptionService: { isConfigured: () => true },
+                spotdlService: { listTracks: async () => [] }
+            }
+        });
+        return { service, tts };
+    }
+
+    test('resolves the voice against the library and persists the resolved ID', async () => {
         const configPath = pathMod.join(os.tmpdir(), `goobster-panel-voice-${process.pid}.json`);
         fsSync.writeFileSync(configPath, JSON.stringify({ token: 'x' }));
         try {
-            const textChannel = makeTextChannel({ id: TEXT_CH, name: 'general' });
-            const guild = makeGuild({ id: GUILD_A, name: 'Alpha', channels: [textChannel] });
-            const tts = { voiceId: 'Rachel' };
-            const service = createPanelService({
-                client: makeClient([guild]),
-                voiceService: { musicService: makeMusicService(), tts, config: { elevenlabs: { voiceId: 'Rachel' } } },
-                logger: { warn: () => {}, error: () => {} },
-                deps: {
-                    configPath,
-                    voiceSessionService: { hasSession: () => false, getSession: () => null },
-                    aiService: { getProvider: () => 'openai', getDefaultModel: () => 'm' },
-                    memoryService: {}, memeMode: {}, guildSettings: {},
-                    factsService: {}, followupService: {}, activityService: {},
-                    aiConfig: { openai: { thoughtfulModel: 'gpt-5.5' } },
-                    transcriptionService: { isConfigured: () => true },
-                    spotdlService: { listTracks: async () => [] }
-                }
+            const { service, tts } = buildVoicePanel({ configPath });
+
+            await expectPanelError(service.setTtsVoice('bad;voice$id'), 400, 'BAD_REQUEST');
+
+            // A voice that isn't in the library is rejected up front,
+            // and nothing is persisted or applied.
+            await expectPanelError(service.setTtsVoice('Rachel'), 400, 'VOICE_NOT_FOUND');
+            expect(tts.voiceId).toBe('Rachel'); // unchanged
+            expect(JSON.parse(fsSync.readFileSync(configPath, 'utf-8')).elevenlabs).toBeUndefined();
+
+            // Base-name matching: "sarah" resolves to the full display name
+            const result = await service.setTtsVoice('sarah');
+            expect(result).toEqual({
+                voiceId: 'EXAVITQu4vr4xnSDxMaL',
+                voiceName: 'Sarah - Mature, Reassuring, Confident'
             });
+            expect(tts.voiceId).toBe('EXAVITQu4vr4xnSDxMaL');
+            expect(tts.voiceName).toBe('Sarah - Mature, Reassuring, Confident');
 
-            expect(() => service.setTtsVoice('bad;voice$id')).toThrow(
-                expect.objectContaining({ code: 'BAD_REQUEST' })
-            );
-
-            const result = service.setTtsVoice('Antoni');
-            expect(result).toEqual({ voiceId: 'Antoni' });
-            expect(tts.voiceId).toBe('Antoni');
             const written = JSON.parse(fsSync.readFileSync(configPath, 'utf-8'));
-            expect(written.elevenlabs.voiceId).toBe('Antoni');
+            expect(written.elevenlabs.voiceId).toBe('EXAVITQu4vr4xnSDxMaL');
+            expect(written.elevenlabs.voiceName).toBe('Sarah - Mature, Reassuring, Confident');
+        } finally {
+            fsSync.unlinkSync(configPath);
+        }
+    });
+
+    test('lists the voice library for the picker', async () => {
+        const configPath = pathMod.join(os.tmpdir(), `goobster-panel-voices-${process.pid}.json`);
+        fsSync.writeFileSync(configPath, JSON.stringify({ token: 'x' }));
+        try {
+            const { service } = buildVoicePanel({ configPath });
+            const voices = await service.listTtsVoices();
+            expect(voices).toHaveLength(2);
+            expect(voices[0].name).toContain('Sarah');
         } finally {
             fsSync.unlinkSync(configPath);
         }

--- a/web/panelApi.js
+++ b/web/panelApi.js
@@ -92,8 +92,12 @@ function createPanelApi({ panelService, logger = console }) {
         res.json(panelService.forgetGuildMemories(req.params.guildId));
     }));
 
+    router.get('/settings/tts-voices', wrap(async (req, res) => {
+        res.json(await panelService.listTtsVoices());
+    }));
+
     router.post('/settings/tts-voice', wrap(async (req, res) => {
-        res.json(panelService.setTtsVoice(req.body?.voiceId));
+        res.json(await panelService.setTtsVoice(req.body?.voiceId));
     }));
 
     router.get('/music/state', wrap(async (req, res) => {

--- a/web/public/app.js
+++ b/web/public/app.js
@@ -560,8 +560,32 @@ function renderSettings() {
     }
 
     $('global-settings-group').classList.toggle('hidden', !s.global.ttsAvailable);
+    $('tts-voice-sub').textContent = s.global.ttsVoiceName
+        ? `Current: ${s.global.ttsVoiceName}`
+        : 'ElevenLabs voice name or ID';
     if (document.activeElement !== $('set-voice-id')) {
-        $('set-voice-id').value = s.global.ttsVoiceId || '';
+        $('set-voice-id').value = s.global.ttsVoiceName || s.global.ttsVoiceId || '';
+    }
+    if (s.global.ttsAvailable) loadVoiceOptions();
+}
+
+let voiceOptionsLoaded = false;
+
+/** Fill the TTS voice picker with the account's real voice library. */
+async function loadVoiceOptions() {
+    if (voiceOptionsLoaded) return;
+    voiceOptionsLoaded = true;
+    try {
+        const voices = await api.get('/api/settings/tts-voices');
+        const datalist = $('voice-options');
+        datalist.innerHTML = '';
+        for (const voice of voices) {
+            const option = document.createElement('option');
+            option.value = voice.name;
+            datalist.appendChild(option);
+        }
+    } catch {
+        voiceOptionsLoaded = false; // picker degrades to free text; retry later
     }
 }
 
@@ -660,8 +684,8 @@ function wireSettings() {
         const voiceId = $('set-voice-id').value.trim();
         if (!voiceId) { toast('Enter a voice name or ID first.', true); return; }
         try {
-            await api.post('/api/settings/tts-voice', { voiceId });
-            toast('TTS voice updated for all servers.');
+            const result = await api.post('/api/settings/tts-voice', { voiceId });
+            toast(`TTS voice set to ${result.voiceName || result.voiceId} for all servers.`);
         } catch (error) {
             reportError(error);
         }

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -179,8 +179,9 @@
         <div class="settings-group" id="global-settings-group">
           <div class="settings-title">Global (all servers)</div>
           <div class="setting-row">
-            <div class="setting-label">TTS voice<span class="setting-sub">ElevenLabs voice name or ID</span></div>
-            <input id="set-voice-id" class="input setting-input" type="text" placeholder="Rachel">
+            <div class="setting-label">TTS voice<span class="setting-sub" id="tts-voice-sub">ElevenLabs voice name or ID</span></div>
+            <input id="set-voice-id" class="input setting-input" type="text" placeholder="Sarah" list="voice-options">
+            <datalist id="voice-options"></datalist>
             <button id="save-voice-id" class="btn">Save</button>
           </div>
         </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The panel's global TTS voice setting (and `/setvoice`) accepted any string and only failed later, at speak time. ElevenLabs retired legacy premade voices like "Rachel", so saving one silently broke TTS — every voice-session utterance failed with `ElevenLabs voice "Rachel" not found in your voice library` (visible in the live bot logs).

## Changes

- **`services/voice/elevenLabsTTSService.js`**: new `listVoices()`, `getVoiceInfo(id)`, and `resolveVoice()` resolve names/IDs against the account's real voice library. Base names match case-insensitively and tolerate display suffixes ("Sarah" → "Sarah - Mature, Reassuring, Confident"); unknown names are rejected with the available voices listed, ambiguous ones (two "Brian"s) too. Resolutions are cached so per-request lookups stay off the network.
- **Manual voice IDs inherit their info**: an ID outside the library list is looked up individually via `GET /v1/voices/{id}`, so pasting a raw voice ID pulls in its real name/category (and persists the canonical `voice_id` ElevenLabs returns — retired IDs get mapped to their replacement). Nonexistent IDs fail the save with a clear error.
- **Speak-time resilience**: `fetchStream` now falls back to the default voice (with a warning) when the configured voice can't be resolved, so an already-broken stored config degrades gracefully instead of silencing TTS entirely.
- **`services/panelService.js`**: `setTtsVoice` resolves the voice **before** persisting and stores the resolved ID + display name in `config.json`; invalid voices fail the save with a clear 400 `VOICE_NOT_FOUND`. New `GET /api/settings/tts-voices` endpoint exposes the library.
- **Panel UI**: the TTS voice input gains a datalist picker populated from the real library, the sub-label shows the current voice name, and the save toast reports the resolved voice.
- **`/setvoice`**: resolves the same way and replies with the resolved voice name + ID.

## Testing

- New `tests/elevenLabsVoiceResolution.test.js` (resolution, ambiguity, caching, manual-ID inheritance, fallback; fetch mocked) and updated `panelService` spec. `npm test`: 14 suites / 125 tests pass; lint 0 errors; smoke clean.
- Live E2E with the real ElevenLabs key and running bot:
  - Saving "Rachel" (name) is rejected with the library listed; saving "Sarah" persists the resolved ID.
  - Saving the raw retired ID `21m00Tcm4TlvDq8ikWAM` inherited its replacement voice info (`eLDc7xhWxG2FElT3kUTj` / "Janet") and persisted the canonical ID; a garbage ID returned a clear 400.
  - Real synthesis with the stored voice returned audio; a legacy broken config fell back to the default voice and still spoke.

[panel_tts_voice_validation_and_picker_demo.mp4](https://cursor.com/agents/bc-817e99e7-82be-4f4e-8ca7-8283c75be7ad/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpanel_tts_voice_validation_and_picker_demo.mp4)
[Rachel rejected with available voices listed](https://cursor.com/agents/bc-817e99e7-82be-4f4e-8ca7-8283c75be7ad/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpanel_tts_voice_rachel_rejected_error.webp)
[Current voice shows Sarah after save](https://cursor.com/agents/bc-817e99e7-82be-4f4e-8ca7-8283c75be7ad/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpanel_tts_voice_current_sarah_saved.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-817e99e7-82be-4f4e-8ca7-8283c75be7ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-817e99e7-82be-4f4e-8ca7-8283c75be7ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

