### PR TITLE
Soften realtime voice barge-in: require sustained speech instead of any mic blip

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,9 @@
 - `/forget-me` now erases economy data (wallet, ledger, holdings, trades); `/what-do-you-know-about-me` reports it
 - New Jest specs: `economyService`, `gamblingService` (incl. poker hand rankings), `stockPortfolioService`
 
+### Fixed
+- Realtime voice barge-in was too aggressive: Discord's speaking-start event (which fires on any mic blip — coughs, breaths, chair squeaks) no longer cuts off Goobster mid-reply. Interruption now requires ~350ms of sustained above-the-noise-gate audio, or actual words heard by the realtime STT; a mic blip still holds back a reply that hasn't started speaking yet
+
 ## 2026-07-18
 
 ### Added

--- a/services/voice/realtimeVoiceEngine.js
+++ b/services/voice/realtimeVoiceEngine.js
@@ -39,6 +39,14 @@ const NOISE_RMS_THRESHOLD = 250;
 // "noisy mic": their speech no longer barges in or blocks turn-taking
 // until they produce words again.
 const MAX_EMPTY_STREAK = 2;
+// Barge-in requires this much cumulative above-the-noise-gate audio in a
+// segment before an in-flight reply is cut off. Discord's speaking-start
+// event alone fires on any mic blip (coughs, breaths, chair squeaks), which
+// made interruptions far too aggressive; a wordful STT partial still barges
+// in immediately regardless of this window.
+const BARGE_IN_SUSTAINED_MS = 350;
+// 48kHz stereo 16-bit = 192 bytes per millisecond of audio
+const BYTES_PER_MS = (SAMPLE_RATE * CHANNELS * BYTES_PER_SAMPLE) / 1000;
 const WORDS_REGEX = /[\p{L}\p{N}]{2,}/u;
 
 /**
@@ -51,8 +59,9 @@ const WORDS_REGEX = /[\p{L}\p{N}]{2,}/u;
  *   -> multi-context TTS WebSocket (audio starts on the first sentence)
  *   -> Discord playback.
  *
- * Barge-in: when a known-wordful speaker starts talking while Goobster is
- * speaking (or a reply is being generated), the TTS context is closed
+ * Barge-in: when a known-wordful speaker talks over Goobster (or over a
+ * reply being generated) with sustained voice energy - not just a mic blip -
+ * or the realtime STT hears actual words, the TTS context is closed
  * server-side, playback stops immediately, and the interrupted reply is
  * recorded as such. The new speech becomes the next turn.
  *
@@ -131,14 +140,39 @@ class RealtimeVoiceEngine {
         const member = session.voiceChannel.guild.members.cache.get(userId);
         if (!member || member.user.bot) return;
 
+        // Hold off a pending reply, but do NOT interrupt an in-flight one
+        // yet: Discord's speaking event fires on any mic blip. Barge-in
+        // happens once the segment shows sustained energy or real words.
         if (!this._isNoisySpeaker(userId)) {
             this._cancelTurnTimer();
-            this._bargeIn('speaking start');
         }
 
         this._captureSegment(userId, member).catch(err => {
             console.error('[RealtimeVoice] Capture error:', err.message);
         });
+    }
+
+    /**
+     * Per-segment tracker: feed it decoded PCM chunks and it triggers ONE
+     * barge-in after BARGE_IN_SUSTAINED_MS of cumulative above-the-gate
+     * audio from a speaker not currently flagged as a noisy mic. Coughs and
+     * short blips never accumulate enough hot audio to interrupt.
+     * @param {string} userId
+     * @returns {(chunk: Buffer) => void}
+     */
+    _createBargeInTracker(userId) {
+        let hotMs = 0;
+        let fired = false;
+        return (chunk) => {
+            if (fired || this.session.stopped) return;
+            if (pcmRms(chunk, 4) < NOISE_RMS_THRESHOLD) return;
+            hotMs += chunk.length / BYTES_PER_MS;
+            if (hotMs >= BARGE_IN_SUSTAINED_MS && !this._isNoisySpeaker(userId)) {
+                fired = true;
+                this._cancelTurnTimer();
+                this._bargeIn('sustained speech');
+            }
+        };
     }
 
     _blockingCaptures() {
@@ -211,8 +245,8 @@ class RealtimeVoiceEngine {
                 if (session.stopped) return;
                 if (WORDS_REGEX.test(text)) {
                     markWordful();
-                    // A previously-noisy mic just produced words mid-reply:
-                    // that counts as a barge-in too.
+                    // The STT heard actual words mid-reply: interrupt right
+                    // away without waiting for the sustained-energy window.
                     this._cancelTurnTimer();
                     this._bargeIn('speech detected');
                 }
@@ -228,6 +262,8 @@ class RealtimeVoiceEngine {
                 console.warn('[RealtimeVoice] Realtime STT connect failed:', error.message);
             });
         };
+
+        const trackBargeIn = this._createBargeInTracker(userId);
 
         const opusStream = session.connection.receiver.subscribe(userId, {
             end: { behavior: EndBehaviorType.AfterSilence, duration: SEGMENT_SILENCE_MS }
@@ -245,6 +281,7 @@ class RealtimeVoiceEngine {
                     if (totalBytes >= maxBytes) return;
                     pcmChunks.push(chunk);
                     totalBytes += chunk.length;
+                    trackBargeIn(chunk);
 
                     if (!hot && pcmRms(chunk, 4) >= NOISE_RMS_THRESHOLD) {
                         hot = true;

--- a/tests/realtimeVoiceEngine.test.js
+++ b/tests/realtimeVoiceEngine.test.js
@@ -44,6 +44,17 @@ function makeMember() {
     };
 }
 
+/**
+ * One decoder-sized chunk of 48kHz stereo s16le PCM (20ms = 3840 bytes)
+ * at a constant amplitude, so pcmRms(chunk) === amplitude.
+ */
+function pcmChunk(amplitude, ms = 20) {
+    const bytes = ms * 192; // 48000Hz * 2ch * 2 bytes / 1000ms
+    const buf = Buffer.alloc(bytes);
+    for (let i = 0; i < bytes; i += 2) buf.writeInt16LE(amplitude, i);
+    return buf;
+}
+
 const liveSessions = [];
 
 function makeSession() {
@@ -248,36 +259,64 @@ describe('realtime voice turns', () => {
         expect(session.turnBuffer[0].text).toBe('Wait, one more thing');
     });
 
-    test('speaking-start from a wordful speaker cancels playback via _onSpeakingStart', async () => {
+    test('speaking start alone holds a pending reply but does not cut playback', async () => {
         const session = makeSession();
         session.voiceChannel.guild.members = { cache: new Map([[USER_ID, makeMember()]]) };
         const engine = makeEngine(session);
         engine._captureSegment = jest.fn().mockResolvedValue(undefined); // no real audio here
 
-        // Simulate an in-flight reply
+        // Simulate an in-flight reply and a scheduled turn-end
         session.responding = true;
+        session.turnTimer = setTimeout(() => {}, 10000);
         engine.currentReply = engine.tts.speak(session.connection);
         const handle = engine.tts.handles[0];
 
         engine._onSpeakingStart(USER_ID);
 
+        // Mic blips (coughs, breaths) must not interrupt playback anymore
+        expect(handle.aborted).toBe(false);
+        expect(engine.interrupted).toBe(false);
+        expect(engine.currentReply).not.toBeNull();
+        // ...but a reply that has not started yet is held back
+        expect(session.turnTimer).toBeNull();
+    });
+
+    test('sustained loud speech barges in; brief blips and noise do not', async () => {
+        const session = makeSession();
+        const engine = makeEngine(session);
+
+        session.responding = true;
+        engine.currentReply = engine.tts.speak(session.connection);
+        const handle = engine.tts.handles[0];
+
+        const track = engine._createBargeInTracker(USER_ID);
+
+        // 300ms of loud audio: under the sustained window, no interrupt yet
+        for (let i = 0; i < 15; i++) track(pcmChunk(5000));
+        expect(handle.aborted).toBe(false);
+
+        // Quiet chunks never accumulate toward the window
+        for (let i = 0; i < 50; i++) track(pcmChunk(40));
+        expect(handle.aborted).toBe(false);
+
+        // Crossing the window interrupts the reply
+        for (let i = 0; i < 3; i++) track(pcmChunk(5000));
         expect(handle.aborted).toBe(true);
         expect(engine.interrupted).toBe(true);
         expect(engine.currentReply).toBeNull();
     });
 
-    test('noisy speakers do not barge in', async () => {
+    test('noisy speakers do not barge in even with sustained loud audio', async () => {
         const session = makeSession();
-        session.voiceChannel.guild.members = { cache: new Map([[USER_ID, makeMember()]]) };
         session.speakers.set(USER_ID, { emptyStreak: 5 }); // flagged as noise
         const engine = makeEngine(session);
-        engine._captureSegment = jest.fn().mockResolvedValue(undefined);
 
         session.responding = true;
         engine.currentReply = engine.tts.speak(session.connection);
         const handle = engine.tts.handles[0];
 
-        engine._onSpeakingStart(USER_ID);
+        const track = engine._createBargeInTracker(USER_ID);
+        for (let i = 0; i < 30; i++) track(pcmChunk(5000)); // 600ms of loud audio
 
         expect(handle.aborted).toBe(false);
         expect(engine.interrupted).toBe(false);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Barge-in in the realtime voice engine was too aggressive: any Discord `speaking.start` event from a non-noisy speaker immediately aborted Goobster's in-flight reply. Discord's speaking event fires on any voice-activity blip — coughs, breaths, chair squeaks, brief background sounds — so Goobster was getting cut off mid-sentence far too often.

## Fix

`speaking.start` no longer interrupts playback. It still cancels a pending turn timer (so a reply that hasn't started yet is held back — cheap and non-destructive), but an in-flight reply is only interrupted when the segment shows real speech:

- **Sustained energy**: a new per-segment tracker (`_createBargeInTracker`) accumulates decoded PCM chunks that cross the existing RMS noise gate (`NOISE_RMS_THRESHOLD = 250`) and fires one barge-in after ~350ms (`BARGE_IN_SUSTAINED_MS`) of cumulative loud audio. Quiet chunks never accumulate, so brief blips can't trigger it.
- **Actual words** (unchanged): a wordful partial from the realtime STT still interrupts immediately, without waiting for the energy window.

Noisy-mic speakers (`emptyStreak >= 2`) still can't barge in via energy alone; the noisiness check happens at fire time, so a mic that produces words mid-segment regains barge-in ability immediately.

## Testing

- Updated `tests/realtimeVoiceEngine.test.js`: speaking-start alone holds a pending reply but no longer aborts playback; sustained loud audio (>350ms above the gate) interrupts while shorter bursts and quiet audio do not; noisy speakers stay unable to barge in even with 600ms of loud audio.
- `npm run lint` (0 errors), `npm test` (21 suites, 189 tests pass), `npm run smoke` (124 modules load cleanly) — the full CI gate set passes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ad4031e-5baa-4048-9881-450767e0c062"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ad4031e-5baa-4048-9881-450767e0c062"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

