### PR TITLE
Activity launch fixes: serve client at the mapped root, guest fallback without OAuth secret

### DIFF
--- a/web/activity/main.js
+++ b/web/activity/main.js
@@ -78,7 +78,29 @@ async function initDiscordMode() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ code })
     });
-    if (!tokenResponse.ok) throw new Error('Login with the game server failed.');
+
+    if (!tokenResponse.ok) {
+        // No client secret configured on the server. When the server runs in
+        // dev mode, fall back to an anonymous guest session so the table is
+        // still playable; otherwise surface the configuration problem.
+        const devResponse = await fetch(`${apiBase}/dev-session`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                userId: String(Date.now()) + String(Math.floor(Math.random() * 1000)),
+                name: `Guest-${Math.random().toString(36).slice(2, 6)}`
+            })
+        });
+        if (!devResponse.ok) {
+            throw new Error('Login failed - is the OAuth client secret configured on the server?');
+        }
+        const { session_token: devToken, user: devUser } = await devResponse.json();
+        me = devUser;
+        connect(devToken, sdk.guildId, sdk.channelId);
+        setTimeout(() => toast(`Playing as ${devUser.name} (dev mode - no Discord login)`), 800);
+        return;
+    }
+
     const { access_token: accessToken, session_token: sessionToken, user } = await tokenResponse.json();
 
     await sdk.commands.authenticate({ access_token: accessToken });

--- a/web/activityApi.js
+++ b/web/activityApi.js
@@ -201,7 +201,13 @@ function createActivityApp(ctx) {
         path.dirname(require.resolve('@discord/embedded-app-sdk/package.json')),
         'output'
     )));
-    app.use('/activity', express.static(path.join(__dirname, 'activity')));
+    const clientDir = path.join(__dirname, 'activity');
+    app.use('/activity', express.static(clientDir));
+    // Discord's proxy loads the Activity iframe at the mapped ROOT path
+    // ("/" plus frame_id query params), so the client must be served there
+    // too. Static (not a redirect) keeps the query params intact. Registered
+    // last so /api/activity and /activity keep precedence.
+    app.use('/', express.static(clientDir));
 
     return app;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two small follow-up fixes to the Goobster Casino Activity (#67), found while launching it inside Discord for real. #67 was squash-merged just before these landed on its branch, so they arrive as a clean follow-up PR instead.

- **Serve the Activity client at the mapped root path.** Discord's proxy loads the Activity iframe at the URL mapping's root (`/` plus `frame_id` query params), which previously answered with Express's `Cannot GET /`. The client static directory is now also mounted at `/` (registered after the API routes so `/api/activity` and `/activity` keep precedence); serving statically rather than redirecting keeps the SDK query params intact.
- **Guest fallback when the OAuth client secret is missing (dev mode only).** Inside Discord, a failed token exchange now falls back to `/api/activity/dev-session` when the server allows it, so the table stays playable during setup — a toast labels the guest identity. With `devMode` off (production), the clearer configuration error is surfaced instead.

## Testing
- Verified live through a cloudflared tunnel + Discord's proxy: `GET /` now returns the game client (200) with query params preserved, and the in-Discord launch proceeds past the previous dead end.
- Full suite still green: 218 tests, lint 0 errors, smoke clean.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63fa5def-0f4a-4f44-8879-4fb444bb2ec8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63fa5def-0f4a-4f44-8879-4fb444bb2ec8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

