### PR TITLE
Never let command registration wedge bot startup (rate-limit hardening)

### DIFF
--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -1,4 +1,4 @@
-const { REST, Routes } = require('discord.js');
+const { REST, Routes, RateLimitError } = require('discord.js');
 const crypto = require('node:crypto');
 const fs = require('node:fs');
 const path = require('node:path');
@@ -85,8 +85,26 @@ if (!FORCE_DEPLOY) {
 	}
 }
 
-// Construct and prepare an instance of the REST module
-const rest = new REST().setToken(token);
+// Construct and prepare an instance of the REST module.
+//
+// Registration must never wedge startup (systemd kills a hung ExecStartPre
+// and the bot never boots): requests get a bounded timeout, and instead of
+// silently sleeping on a long Discord rate limit (the default behavior),
+// the request rejects with RateLimitError so we can log it and move on.
+const LONG_RATE_LIMIT_MS = 25 * 1000;
+const rest = new REST({
+	timeout: 15_000,
+	retries: 1,
+	rejectOnRateLimit: (rateLimitData) => rateLimitData.timeToReset > LONG_RATE_LIMIT_MS
+}).setToken(token);
+
+rest.on('rateLimited', (rateLimitData) => {
+	console.warn('Discord rate limit hit during command registration:', {
+		route: rateLimitData.route,
+		global: rateLimitData.global,
+		timeToResetMs: rateLimitData.timeToReset
+	});
+});
 
 try {
 	const configValidation = validateConfig(config);
@@ -96,6 +114,15 @@ try {
 	}
 
 	(async () => {
+		// Watchdog: if Discord is slow or rate limiting beyond all the
+		// bounds above, start the bot anyway with the previously registered
+		// commands. The deploy hash is not written, so registration is
+		// retried on the next boot.
+		setTimeout(() => {
+			console.warn('Command registration did not finish within 60s - continuing startup with previously registered commands (will retry on next boot).');
+			process.exit(0);
+		}, 60_000);
+
 		try {
 			console.log(`Started refreshing application (/) commands.`);
 			console.log(`Client ID: ${clientId}`);
@@ -159,6 +186,18 @@ try {
 
 			process.exit(0);
 		} catch (error) {
+			// A rate-limited or timed-out registration is not fatal: the
+			// commands registered on the last successful boot keep working.
+			// Exit 0 (without writing the deploy hash) so the bot starts
+			// and registration is retried on the next boot.
+			if (error instanceof RateLimitError || error.name === 'AbortError') {
+				console.warn(
+					'Discord rate limited (or timed out) command registration - ' +
+					'continuing startup with previously registered commands (will retry on next boot).',
+					error.message
+				);
+				process.exit(0);
+			}
 			console.error('Failed to deploy commands:', error);
 			process.exit(1);
 		}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #80. With the Entry Point fix deployed, startup on the Pi still failed - but differently: `deploy-commands.js` finished all six guild deploys and the Entry Point fetch in ~2s, then **hung silently** until systemd's `ExecStartPre` start timeout (90s) killed it:

```
Jul 23 12:30:06 ... Preserving 1 Entry Point command(s): [ 'launch' ]
Jul 23 12:30:06 ... Successfully reloaded 41 commands for guild ...   (x6)
(...nothing but MusicService memory-usage logs until systemd TERM...)
```

The cause: `@discordjs/rest` **sleeps silently** when Discord rate limits a route, and the global bulk-overwrite commands route is aggressively limited - made worse by today's crash-loop, since every restart issued another global `PUT`, and the deploy hash (which lets unchanged boots skip registration entirely) is only written after full success.

## Fix

`deploy-commands.js` can no longer hang or fail the service over rate limiting:

- The REST client gets a bounded timeout (15s, 1 retry) and `rejectOnRateLimit`: any rate limit needing more than 25s rejects with `RateLimitError` instead of sleeping. A `rateLimited` listener logs the route, scope, and reset time to the journal so the cause is visible.
- Rate-limited or timed-out registration is treated as non-fatal: **exit 0 with a warning**. The commands registered on the last successful boot keep working, the deploy hash is not written, and registration retries on the next boot. Real API errors (bad payloads, auth) still exit 1.
- A 60-second watchdog guarantees the script always terminates well inside systemd's start timeout.

## Testing

- `npm test`: 463/463 passing; `npm run lint`: 0 errors; `npm run smoke`: 144 modules clean; REST option/listener wiring verified against the installed discord.js.
- The hang requires Discord's live rate limiter, so please verify on the Pi: `sudo systemctl start goobster` should now always get past `ExecStartPre` within ~60s. If Discord is still rate limiting, the journal will show `Discord rate limit hit during command registration: { route, timeToResetMs, ... }` followed by a warning that startup continues - and the bot should log `Ready! Logged in as <tag>`. Once the limit cools down, a later restart registers the 14 global commands and writes the skip-hash so subsequent boots don't touch the API at all.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8fff-168a-712f-914d-f4cd9e9fc888"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8fff-168a-712f-914d-f4cd9e9fc888"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

