### PR TITLE
Fix GitHub webhook delivery with Activity enabled

### DIFF
--- a/commands/utility/github.js
+++ b/commands/utility/github.js
@@ -223,11 +223,19 @@ module.exports = {
             }
         } catch (error) {
             console.error('GitHub command failed:', error);
+            // 10062 (Unknown interaction) / 40060 (already acknowledged) are
+            // transient Discord-side races: no response can be delivered, and
+            // retrying just cascades more errors.
+            if (error.code === 10062 || error.code === 40060) return;
             const message = `❌ ${error.message || 'Something went wrong talking to GitHub.'}`;
-            if (interaction.deferred || interaction.replied) {
-                await interaction.editReply(message);
-            } else {
-                await interaction.reply({ content: message, ephemeral: true });
+            try {
+                if (interaction.deferred || interaction.replied) {
+                    await interaction.editReply(message);
+                } else {
+                    await interaction.reply({ content: message, ephemeral: true });
+                }
+            } catch (replyError) {
+                console.error('GitHub command error reply failed:', replyError);
             }
         }
     }

--- a/index.js
+++ b/index.js
@@ -449,6 +449,9 @@ client.on(Events.InteractionCreate, async interaction => {
 			await command.execute(interaction);
 		} catch (error) {
 			logger.error(`Error executing context menu command ${interaction.commandName}:`, error);
+			// 10062/40060: transient Discord interaction races - the token is
+			// dead or the ack already landed, so no error message can be sent.
+			if (error.code === 10062 || error.code === 40060) return;
 			const errorMessage = 'There was an error while executing this command!';
 			try {
 				if (interaction.replied || interaction.deferred) {
@@ -480,6 +483,9 @@ client.on(Events.InteractionCreate, async interaction => {
 		await command.execute(interaction, client.musicService);
 	} catch (error) {
 		logger.error(`Error in ${interaction.commandName} command:`, error);
+		// 10062/40060: transient Discord interaction races - the token is
+		// dead or the ack already landed, so no error message can be sent.
+		if (error.code === 10062 || error.code === 40060) return;
 		const errorMessage = 'There was an error while executing this command!';
 		try {
 			if (interaction.replied || interaction.deferred) {

--- a/tests/integrationsWebhooks.test.js
+++ b/tests/integrationsWebhooks.test.js
@@ -160,6 +160,10 @@ describe('webhook receivers (HTTP end-to-end)', () => {
         expect(verifySignature('secret', body, 'sha256=zz')).toBe(false);
         expect(verifySignature('secret', body, null)).toBe(false);
         expect(verifySignature(null, body, sign('secret', body))).toBe(false);
+        // A body already parsed by an upstream JSON middleware must be
+        // rejected, never crash Hmac.update().
+        expect(verifySignature('secret', { a: 1 }, sign('secret', body))).toBe(false);
+        expect(verifySignature('secret', undefined, sign('secret', body))).toBe(false);
     });
 
     test('GitHub receiver rejects bad signatures and delivers good ones', async () => {
@@ -235,5 +239,70 @@ describe('webhook receivers (HTTP end-to-end)', () => {
     test('agent tracker ignores updates for unknown agents', async () => {
         await tracker.applyUpdate({ agentId: 'bc-unknown', status: 'FINISHED' });
         expect(fakeClient.sent).toHaveLength(0);
+    });
+});
+
+describe('public server composition (activity + webhook receivers)', () => {
+    // Regression for the middleware-ordering bug: the Activity router's
+    // router-wide express.json() used to consume webhook bodies first, so
+    // GitHub deliveries failed with 413 (>16kb) or a Hmac TypeError (<16kb).
+    let server;
+    let baseUrl;
+    let originalGithubSecret;
+
+    beforeAll(async () => {
+        originalGithubSecret = integrationsConfig.github.webhookSecret;
+        integrationsConfig.github.webhookSecret = GITHUB_SECRET;
+
+        const { createHealthApp } = require('../web/server');
+        const { createActivityApp } = require('../web/activityApi');
+        const app = createHealthApp({ logger: { debug: () => {} } });
+        // Worst-case mount order (activity first) to prove the webhook
+        // receivers survive it regardless of web/server.js ordering.
+        app.use(createActivityApp({ clientId: 'test-client', devMode: true, sessions: new Map(), logger: console }));
+        app.use(createIntegrationsApp({ client: makeFakeClient().client, logger: { warn: () => {}, error: () => {} } }));
+        await new Promise(resolve => {
+            server = app.listen(0, '127.0.0.1', resolve);
+        });
+        baseUrl = `http://127.0.0.1:${server.address().port}`;
+    });
+
+    afterAll(async () => {
+        integrationsConfig.github.webhookSecret = originalGithubSecret;
+        await new Promise(resolve => server.close(resolve));
+    });
+
+    function postGithub(body) {
+        return fetch(`${baseUrl}/api/webhooks/github`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json', 'x-github-event': 'push', 'x-hub-signature-256': sign(GITHUB_SECRET, body) },
+            body
+        });
+    }
+
+    test('small signed webhook is ACKed (raw body not consumed upstream)', async () => {
+        const response = await postGithub(JSON.stringify({ zen: 'ping', repository: { full_name: 'o/r' } }));
+        expect(response.status).toBe(202);
+    });
+
+    test('large signed webhook (>16kb) is ACKed (no activity-size limit applied)', async () => {
+        const body = JSON.stringify({
+            repository: { full_name: 'o/r' },
+            commits: Array.from({ length: 300 }, (_, i) => ({ id: String(i), message: 'x'.repeat(100) }))
+        });
+        expect(body.length).toBeGreaterThan(16 * 1024);
+        const response = await postGithub(body);
+        expect(response.status).toBe(202);
+    });
+
+    test('activity API still parses JSON bodies on its own routes', async () => {
+        const response = await fetch(`${baseUrl}/api/activity/dev-session`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ userId: '600000000000000003', name: 'tester' })
+        });
+        expect(response.status).toBe(200);
+        const payload = await response.json();
+        expect(payload.user).toEqual({ id: '600000000000000003', name: 'tester' });
     });
 });

--- a/web/activityApi.js
+++ b/web/activityApi.js
@@ -112,7 +112,10 @@ function getSession(ctx, token) {
  */
 function createActivityApp(ctx) {
     const app = express.Router();
-    app.use(express.json({ limit: '16kb' }));
+    // Scoped to the activity API only: this router is mounted at the root of
+    // the public server, and a router-wide parser would consume request
+    // bodies destined for other mounts (e.g. the raw-body webhook receivers).
+    app.use('/api/activity', express.json({ limit: '16kb' }));
 
     // Client bootstrap info (nothing secret: the client id is public)
     app.get('/api/activity/config', (req, res) => {

--- a/web/integrationsApi.js
+++ b/web/integrationsApi.js
@@ -18,6 +18,9 @@ const repoWatchService = require('../services/repoWatchService');
  */
 function verifySignature(secret, rawBody, signatureHeader) {
     if (!secret || !signatureHeader) return false;
+    // Guard against an upstream body parser having consumed the raw body:
+    // HMAC verification is only meaningful over the exact bytes on the wire.
+    if (!Buffer.isBuffer(rawBody) && typeof rawBody !== 'string') return false;
     const provided = String(signatureHeader).replace(/^sha256=/i, '').trim();
     const expected = crypto.createHmac('sha256', secret).update(rawBody).digest('hex');
     const providedBuffer = Buffer.from(provided, 'hex');

--- a/web/server.js
+++ b/web/server.js
@@ -88,6 +88,16 @@ function startWebServers({ client, voiceService, config = {}, logger = console }
     const healthPort = Number(process.env.PORT) || 3000;
     const healthApp = createHealthApp({ logger });
 
+    // Webhook receivers (GitHub + Cursor agent status): enabled per-receiver
+    // by configuring its shared secret. Like the Activity API, these must be
+    // publicly reachable (e.g. via a cloudflared tunnel). Mounted before the
+    // Activity app so its body parsers can never touch the raw webhook
+    // bodies needed for HMAC signature verification.
+    if (integrationsWebhooksEnabled()) {
+        healthApp.use(createIntegrationsApp({ client, logger }));
+        logger.info?.('Integration webhook receivers enabled at /api/webhooks/*');
+    }
+
     // Discord Activity (table games): opt-in because it makes the public
     // server serve more than /health - it must be reachable by Discord's
     // proxy (e.g. via a cloudflared tunnel). See documentation/activity_setup.md.
@@ -101,14 +111,6 @@ function startWebServers({ client, voiceService, config = {}, logger = console }
         healthApp.use(createActivityApp(activityContext));
         healthApp.locals.activityContext = activityContext;
         logger.info?.(`Activity server enabled at /activity${activityContext.devMode ? ' (DEV MODE - auth bypass on)' : ''}`);
-    }
-
-    // Webhook receivers (GitHub + Cursor agent status): enabled per-receiver
-    // by configuring its shared secret. Like the Activity API, these must be
-    // publicly reachable (e.g. via a cloudflared tunnel).
-    if (integrationsWebhooksEnabled()) {
-        healthApp.use(createIntegrationsApp({ client, logger }));
-        logger.info?.('Integration webhook receivers enabled at /api/webhooks/*');
     }
 
     const healthServer = healthApp.listen(healthPort, () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- scope Activity JSON parsing to `/api/activity` so webhook requests retain their raw bodies
- mount webhook receivers before Activity routes and reject non-raw signature inputs safely
- stop transient Discord interaction errors `10062` and `40060` from cascading into repeated failed replies
- add regression coverage for small and >16 KB signed GitHub webhook payloads when Activity routes are mounted

## Testing
- `npm run lint` (0 errors; 37 existing warnings)
- `npm run smoke` (156 modules loaded, 0 failed)
- `npm test` (46 suites, 524 tests passed)
- focused webhook suite with `--detectOpenHandles` (11 tests passed)
- reproduction script: small and 37 KB signed webhooks both return HTTP 202 with Activity mounted
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9db758f4-c471-4806-b3fa-39d5da4d05d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9db758f4-c471-4806-b3fa-39d5da4d05d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

