### PR TITLE
Screen companion native binaries (.exe/.dmg) + install-page downloads

### DIFF
--- a/.github/workflows/release-companion.yml
+++ b/.github/workflows/release-companion.yml
@@ -1,0 +1,122 @@
+# Builds native, no-Node-required binaries of the screen-vision companion
+# (clients/screen-companion/companion.js) with Node's Single Executable
+# Application tooling, on each platform's own runner:
+#
+#   goobster-companion-win-x64.exe      (windows-latest)
+#   goobster-companion-macos-x64.dmg    (macos-13, Intel)
+#   goobster-companion-macos-arm64.dmg  (macos-latest, Apple Silicon)
+#   goobster-companion-linux-x64        (ubuntu-latest)
+#
+# Push a tag like `companion-v2.1.0` to build AND publish a GitHub Release
+# with the binaries attached; the /companion install page links to
+# .../releases/latest/download/<asset>. Run manually (workflow_dispatch) to
+# just build and inspect the artifacts without releasing.
+
+name: Release companion binaries
+
+on:
+  push:
+    tags: ['companion-v*']
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            binary: goobster-companion-linux-x64
+            asset: goobster-companion-linux-x64
+          - os: windows-latest
+            binary: goobster-companion-win-x64.exe
+            asset: goobster-companion-win-x64.exe
+          - os: macos-13
+            binary: goobster-companion-macos-x64
+            asset: goobster-companion-macos-x64.dmg
+          - os: macos-latest
+            binary: goobster-companion-macos-arm64
+            asset: goobster-companion-macos-arm64.dmg
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: clients/screen-companion
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Build SEA preparation blob
+        run: node --experimental-sea-config sea-config.json
+
+      - name: Assemble binary (Linux/macOS)
+        if: runner.os != 'Windows'
+        run: |
+          cp "$(command -v node)" "${{ matrix.binary }}"
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            codesign --remove-signature "${{ matrix.binary }}"
+            npx --yes postject "${{ matrix.binary }}" NODE_SEA_BLOB sea-prep.blob \
+              --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2 \
+              --macho-segment-name NODE_SEA
+            codesign -s - "${{ matrix.binary }}"
+          else
+            npx --yes postject "${{ matrix.binary }}" NODE_SEA_BLOB sea-prep.blob \
+              --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2
+          fi
+          chmod +x "${{ matrix.binary }}"
+
+      - name: Assemble binary (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          node -e "require('fs').copyFileSync(process.execPath, '${{ matrix.binary }}')"
+          npx --yes postject "${{ matrix.binary }}" NODE_SEA_BLOB sea-prep.blob --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2
+
+      - name: Smoke test
+        run: ./${{ matrix.binary }} --version
+
+      - name: Package .dmg (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          mkdir -p dmg-root
+          cp "${{ matrix.binary }}" dmg-root/goobster-companion
+          hdiutil create -volname "Goobster Companion" -srcfolder dmg-root -ov -format UDZO "${{ matrix.asset }}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset }}
+          path: clients/screen-companion/${{ matrix.asset }}
+          if-no-files-found: error
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/companion-v')
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+          path: dist
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          name: Screen Companion ${{ github.ref_name }}
+          body: |
+            Native builds of the Goobster screen-vision companion - no Node.js required.
+
+            | Platform | File |
+            |---|---|
+            | Windows (x64) | `goobster-companion-win-x64.exe` |
+            | macOS (Apple Silicon) | `goobster-companion-macos-arm64.dmg` |
+            | macOS (Intel) | `goobster-companion-macos-x64.dmg` |
+            | Linux (x64) | `goobster-companion-linux-x64` |
+
+            Run it and follow the prompts (get a pairing code with `/screenvision link` in Discord).
+            Binaries are unsigned: Windows SmartScreen -> "More info" -> "Run anyway";
+            macOS -> right-click -> Open (or `xattr -d com.apple.quarantine <file>`).
+          files: dist/*

--- a/clients/screen-companion/.gitignore
+++ b/clients/screen-companion/.gitignore
@@ -2,3 +2,6 @@ node_modules/
 package-lock.json
 companion.config.json
 goobster-companion.json
+sea-prep.blob
+goobster-companion-*
+*.dmg

--- a/clients/screen-companion/README.md
+++ b/clients/screen-companion/README.md
@@ -14,8 +14,15 @@ attached to the AI request and then discarded — it is never stored.
 
 ## Install — no repo clone needed
 
-The companion is a **single zero-dependency file** (`companion.js`) that
-Goobster serves himself. Players never need this repository:
+**Easiest: the native app.** When the bot owner has published binaries
+(see `.github/workflows/release-companion.yml` — push a `companion-v*` tag),
+the install page offers `.exe` / `.dmg` / Linux downloads that need no Node
+at all: run the app and paste your server URL + pairing code when prompted.
+Pairing is saved to `~/.goobster-companion.json`.
+
+**Or run the single file with Node.** The companion is also a **single
+zero-dependency file** (`companion.js`) that Goobster serves himself.
+Players never need this repository:
 
 1. In Discord, run `/screenvision link` — Goobster replies with a personal
    install link (`https://<goobster-host>/companion?code=XXXX-XXXX`) showing

--- a/clients/screen-companion/companion.js
+++ b/clients/screen-companion/companion.js
@@ -16,13 +16,17 @@
  * own tools: PowerShell (Windows), screencapture (macOS), or
  * import/gnome-screenshot/grim (Linux).
  *
- * Get it (no repo clone needed - Goobster serves this file himself):
+ * Get it (no repo clone needed - Goobster serves this file himself, and the
+ * install page also offers prebuilt .exe/.dmg/linux binaries that need no
+ * Node install at all):
  *   curl -fsSL https://<your-goobster-host>/companion.js -o goobster-companion.js
  *
  * First run (pair):  node goobster-companion.js --server https://<host> --code XXXX-XXXX [--label "Gaming PC"]
+ *   ...or just run it with no arguments and answer the prompts (this is
+ *   what double-clicking the packaged .exe does).
  * After that:        node goobster-companion.js
  *
- * The token is saved in goobster-companion.json next to this file.
+ * The token is saved in .goobster-companion.json in your home folder.
  */
 
 const fs = require('node:fs');
@@ -31,7 +35,8 @@ const os = require('node:os');
 const crypto = require('node:crypto');
 const { execFile } = require('node:child_process');
 
-const CONFIG_PATH = path.join(path.dirname(process.argv[1] || __filename), 'goobster-companion.json');
+const VERSION = '2.1.0';
+const CONFIG_PATH = path.join(os.homedir(), '.goobster-companion.json');
 const RECONNECT_MIN_MS = 3000;
 const RECONNECT_MAX_MS = 60000;
 
@@ -50,8 +55,39 @@ function parseArgs(argv) {
         if (argv[i] === '--server') args.server = argv[++i];
         else if (argv[i] === '--code') args.code = argv[++i];
         else if (argv[i] === '--label') args.label = argv[++i];
+        else if (argv[i] === '--version' || argv[i] === '-v') args.version = true;
     }
     return args;
+}
+
+/**
+ * First-run setup for people who just double-clicked the packaged binary:
+ * ask for the server URL and pairing code instead of demanding CLI flags.
+ */
+async function promptPairing() {
+    const readline = require('node:readline/promises');
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    console.log('Goobster Screen Companion - first-time setup');
+    console.log('Get a pairing code by running /screenvision link in Discord.\n');
+    try {
+        const server = (await rl.question('Goobster server URL (e.g. https://goobster.example.com): ')).trim();
+        const code = (await rl.question('Pairing code (XXXX-XXXX): ')).trim();
+        return { server, code };
+    } finally {
+        rl.close();
+    }
+}
+
+/** Keep the console window open on failure so double-click users see why. */
+async function fatal(message) {
+    console.error(message);
+    if (process.stdin.isTTY) {
+        const readline = require('node:readline/promises');
+        const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+        await rl.question('\nPress Enter to close...');
+        rl.close();
+    }
+    process.exit(1);
 }
 
 function loadConfig() {
@@ -279,23 +315,39 @@ function connect(config) {
 (async () => {
     const args = parseArgs(process.argv);
 
-    if (args.code) {
-        if (!args.server) {
-            console.error('Pairing needs both --server and --code, e.g.\n  node goobster-companion.js --server https://your-goobster-host --code XXXX-XXXX');
-            process.exit(1);
+    if (args.version) {
+        console.log(`goobster-screen-companion ${VERSION} (node ${process.version}, ${process.platform}-${process.arch})`);
+        process.exit(0);
+    }
+
+    if (args.code && !args.server) {
+        await fatal('Pairing needs both --server and --code, e.g.\n  node goobster-companion.js --server https://your-goobster-host --code XXXX-XXXX');
+    }
+
+    let pairing = args.code ? { server: args.server, code: args.code } : null;
+
+    // No saved pairing and no flags: interactive setup (double-clicked binary)
+    if (!pairing && !loadConfig()?.token) {
+        if (!process.stdin.isTTY) {
+            await fatal(`No pairing found (${CONFIG_PATH}). Run /screenvision link in Discord, then:\n  node goobster-companion.js --server https://your-goobster-host --code XXXX-XXXX`);
         }
+        pairing = await promptPairing();
+        if (!pairing.server || !pairing.code) {
+            await fatal('Both the server URL and the pairing code are required.');
+        }
+    }
+
+    if (pairing) {
         try {
-            await pair(args.server, args.code, args.label);
+            await pair(pairing.server, pairing.code, args.label);
         } catch (error) {
-            console.error(`Pairing failed: ${error.message}`);
-            process.exit(1);
+            await fatal(`Pairing failed: ${error.message}`);
         }
     }
 
     const config = loadConfig();
     if (!config?.token || !config?.server) {
-        console.error(`No pairing found (${CONFIG_PATH}). Run /screenvision link in Discord, then:\n  node goobster-companion.js --server https://your-goobster-host --code XXXX-XXXX`);
-        process.exit(1);
+        await fatal(`No pairing found (${CONFIG_PATH}). Run /screenvision link in Discord, then:\n  node goobster-companion.js --server https://your-goobster-host --code XXXX-XXXX`);
     }
 
     connect(config);

--- a/clients/screen-companion/sea-config.json
+++ b/clients/screen-companion/sea-config.json
@@ -1,0 +1,5 @@
+{
+    "main": "companion.js",
+    "output": "sea-prep.blob",
+    "disableExperimentalSEAWarning": true
+}

--- a/config.example.json
+++ b/config.example.json
@@ -23,7 +23,8 @@
 
     "screenVision": {
         "enabled": false,
-        "publicUrl": ""
+        "publicUrl": "",
+        "releasesUrl": ""
     },
 
     "ai": {

--- a/documentation/screen_vision_setup.md
+++ b/documentation/screen_vision_setup.md
@@ -30,7 +30,8 @@ Everything is **off by default**. In `config.json`:
 {
     "screenVision": {
         "enabled": true,
-        "publicUrl": "https://your-goobster-domain.example.com"
+        "publicUrl": "https://your-goobster-domain.example.com",
+        "releasesUrl": "https://github.com/<owner>/<repo>/releases/latest"
     }
 }
 ```
@@ -55,14 +56,40 @@ deploy-commands` once so the `/screenvision` command registers.
 
 1. `/screenvision link` in Discord → one-time code (10 min, single use) plus
    a personal install link (`https://<domain>/companion?code=XXXX-XXXX`).
-2. On the gaming PC, follow the link's copy-paste commands — effectively:
-   `curl -fsSL https://<domain>/companion.js -o goobster-companion.js` then
-   `node goobster-companion.js --server https://<domain> --code XXXX-XXXX`.
-   Only [Node.js 22+](https://nodejs.org) is required; screenshots use the
-   OS's own tools (PowerShell / `screencapture` / `import`/`grim`).
+2. On the gaming PC, either **download the native app** (Option A on the
+   install page: `.exe` / `.dmg` / Linux binary, no Node required — run it
+   and paste the server URL + code when prompted) or **run the single file
+   with Node** — `curl -fsSL https://<domain>/companion.js -o
+   goobster-companion.js` then `node goobster-companion.js --server
+   https://<domain> --code XXXX-XXXX` ([Node.js 22+](https://nodejs.org)).
+   Screenshots use the OS's own tools either way (PowerShell /
+   `screencapture` / `import`/`grim`).
 3. `/screenvision test` → Goobster replies ephemerally with exactly what he
    can see. `/screenvision status` shows the connection; `/screenvision
    unlink` revokes the token.
+
+## Native binaries (.exe / .dmg)
+
+`.github/workflows/release-companion.yml` builds the companion as
+self-contained executables with Node's Single Executable Application
+tooling, on native runners for each platform:
+
+- `goobster-companion-win-x64.exe`
+- `goobster-companion-macos-arm64.dmg` / `goobster-companion-macos-x64.dmg`
+- `goobster-companion-linux-x64`
+
+**To publish a release:** push a tag like `companion-v2.1.0` (or run the
+workflow manually to build artifacts without releasing). The workflow
+creates a GitHub Release with the binaries attached. Set
+`screenVision.releasesUrl` to your repo's
+`https://github.com/<owner>/<repo>/releases/latest` and the `/companion`
+install page shows the download links automatically.
+
+The binaries are unsigned (no paid certificates): Windows SmartScreen needs
+"More info → Run anyway", macOS needs right-click → Open (or
+`xattr -d com.apple.quarantine <file>`). Double-clicking prompts
+interactively for the server URL + pairing code, so no terminal knowledge is
+required; the pairing is saved to `~/.goobster-companion.json`.
 
 ## How it flows
 

--- a/services/screenVisionService.js
+++ b/services/screenVisionService.js
@@ -50,10 +50,16 @@ class ScreenVisionService {
         this._requestSeq = 0;
     }
 
-    configure({ enabled = false, publicUrl = null, logger = console } = {}) {
+    configure({ enabled = false, publicUrl = null, releasesUrl = null, logger = console } = {}) {
         this.enabled = Boolean(enabled);
         this.publicUrl = typeof publicUrl === 'string' && publicUrl.trim()
             ? publicUrl.trim().replace(/\/+$/, '')
+            : null;
+        // GitHub "latest release" URL whose assets are the packaged companion
+        // binaries (built by .github/workflows/release-companion.yml). The
+        // install page offers .exe/.dmg downloads when this is set.
+        this.releasesUrl = typeof releasesUrl === 'string' && releasesUrl.trim()
+            ? releasesUrl.trim().replace(/\/+$/, '')
             : null;
         this.logger = logger;
     }

--- a/tests/screenVisionService.test.js
+++ b/tests/screenVisionService.test.js
@@ -131,6 +131,24 @@ describe('pairing lifecycle', () => {
         }
     });
 
+    test('install page shows binary downloads only when a releases URL is configured', async () => {
+        const withoutReleases = await (await fetch(`http://127.0.0.1:${port}/companion`)).text();
+        expect(withoutReleases).not.toContain('__RELEASES_URL__'); // placeholder always replaced
+        expect(withoutReleases).toContain("var releasesUrl = '';");
+
+        screenVisionService.configure({
+            enabled: true,
+            releasesUrl: 'https://github.com/example/goobster/releases/latest',
+            logger: silentLogger
+        });
+        try {
+            const withReleases = await (await fetch(`http://127.0.0.1:${port}/companion`)).text();
+            expect(withReleases).toContain("var releasesUrl = 'https://github.com/example/goobster/releases/latest';");
+        } finally {
+            screenVisionService.configure({ enabled: true, logger: silentLogger });
+        }
+    });
+
     test('getInstallUrl reflects the configured public URL', () => {
         screenVisionService.configure({ enabled: true, publicUrl: 'https://goob.example.com/', logger: silentLogger });
         expect(screenVisionService.getInstallUrl('AAAA-2222')).toBe('https://goob.example.com/companion?code=AAAA-2222');

--- a/web/screen-companion.html
+++ b/web/screen-companion.html
@@ -77,7 +77,19 @@
         </div>
     </div>
 
-    <h2>Install Node.js (once)</h2>
+    <section id="binary-section" hidden>
+        <h2>Option A - Download the app (no Node.js needed)</h2>
+        <div class="card">
+            <p style="margin:.25rem 0 .75rem">Grab the build for your machine, run it, and paste your
+            server URL + pairing code when prompted:</p>
+            <p style="margin:0" id="binary-links"></p>
+            <p class="warn" style="margin:.75rem 0 0">The binaries are unsigned: Windows SmartScreen →
+            "More info" → "Run anyway"; macOS → right-click → Open.</p>
+        </div>
+        <h2 id="node-option-title">Option B - Run with Node.js</h2>
+    </section>
+
+    <h2 id="node-title">Install Node.js (once)</h2>
     <div class="card">
         Node.js <strong>22 or newer</strong> is the only requirement:
         <a href="https://nodejs.org" target="_blank" rel="noopener">nodejs.org</a>.
@@ -121,6 +133,22 @@
 (function () {
     var origin = location.origin;
     var code = new URLSearchParams(location.search).get('code') || '';
+
+    // Injected by the server from config.screenVision.releasesUrl
+    var releasesUrl = '__RELEASES_URL__';
+    if (releasesUrl && releasesUrl.indexOf('__') !== 0) {
+        var assets = [
+            ['Windows', 'goobster-companion-win-x64.exe'],
+            ['macOS (Apple Silicon)', 'goobster-companion-macos-arm64.dmg'],
+            ['macOS (Intel)', 'goobster-companion-macos-x64.dmg'],
+            ['Linux', 'goobster-companion-linux-x64']
+        ];
+        document.getElementById('binary-links').innerHTML = assets.map(function (a) {
+            return '<a href="' + releasesUrl + '/download/' + a[1] + '">⬇️ ' + a[0] + '</a>';
+        }).join(' &nbsp;·&nbsp; ');
+        document.getElementById('binary-section').hidden = false;
+        document.getElementById('node-title').hidden = true;
+    }
     var validCode = /^[A-Z2-9]{4}-[A-Z2-9]{4}$/.test(code);
     document.getElementById(validCode ? 'code-card' : 'no-code-card').hidden = false;
     if (validCode) document.getElementById('pair-code').textContent = code;

--- a/web/screenVisionApi.js
+++ b/web/screenVisionApi.js
@@ -17,6 +17,7 @@
  * route exists and the public server keeps serving only what it did before.
  */
 
+const fs = require('node:fs');
 const path = require('node:path');
 const express = require('express');
 const { WebSocketServer } = require('ws');
@@ -45,9 +46,17 @@ function createScreenVisionApp({ logger = console } = {}) {
     });
 
     // Self-serve install: players download the single-file companion from
-    // the bot itself, no repo clone or npm install needed.
+    // the bot itself, no repo clone or npm install needed. The page also
+    // offers native .exe/.dmg downloads when a releases URL is configured
+    // (injected here - the page is otherwise static).
     app.get('/companion', (req, res) => {
-        res.sendFile(COMPANION_PAGE);
+        fs.readFile(COMPANION_PAGE, 'utf8', (error, html) => {
+            if (error) {
+                res.status(500).send('Install page unavailable');
+                return;
+            }
+            res.type('html').send(html.replace('__RELEASES_URL__', screenVisionService.releasesUrl || ''));
+        });
     });
     app.get('/companion.js', (req, res) => {
         res.type('application/javascript; charset=utf-8');

--- a/web/server.js
+++ b/web/server.js
@@ -123,6 +123,7 @@ function startWebServers({ client, voiceService, config = {}, logger = console }
     screenVisionService.configure({
         enabled: screenVisionEnabled,
         publicUrl: config.screenVision?.publicUrl,
+        releasesUrl: config.screenVision?.releasesUrl,
         logger
     });
     if (screenVisionEnabled) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Follow-up to #90: native, **no-Node-required** builds of the screen-vision companion, so players can just download and double-click an app.

- `.github/workflows/release-companion.yml` — builds self-contained executables with Node's Single Executable Application (SEA) tooling on each platform's own runner:
  - `goobster-companion-win-x64.exe` (windows-latest)
  - `goobster-companion-macos-arm64.dmg` / `goobster-companion-macos-x64.dmg` (macOS runners, packaged with `hdiutil`)
  - `goobster-companion-linux-x64` (ubuntu-latest)

  **Push a tag like `companion-v2.1.0` to build and publish a GitHub Release** with the binaries attached; run the workflow manually (`workflow_dispatch`) to build inspectable artifacts without releasing.
- `clients/screen-companion/companion.js`:
  - interactive first-run: running with no arguments (i.e. double-clicking the binary) prompts for the server URL + pairing code — no terminal knowledge needed
  - config moved to `~/.goobster-companion.json` (binaries can't reliably write next to themselves)
  - `--version` flag (used as the CI smoke test)
  - fatal errors hold the console open so double-click users can read the message
- Install page (`/companion`): a "Download the app (no Node.js needed)" section with per-platform links, shown when `screenVision.releasesUrl` (e.g. `https://github.com/<owner>/<repo>/releases/latest`) is configured — injected server-side, page stays static otherwise.

Binaries are unsigned (no paid certs): Windows SmartScreen → "More info" → "Run anyway"; macOS → right-click → Open. Documented on the install page, in the release notes template, and in `documentation/screen_vision_setup.md`.

## Testing

- Full suite: 59 suites / 661 tests pass (new specs: releases-URL injection into the install page); lint 0 errors; smoke clean.
- **SEA recipe verified live on Linux** with the exact workflow steps: built `goobster-companion-linux-x64`, `--version` smoke test passed, and the packaged binary paired, connected, captured a real screenshot, and produced a correct board-grounded AI answer through the full pipeline. Windows/macOS use the same recipe on native CI runners.
- Interactive first-run prompts verified under a pseudo-TTY.

## After merging

1. Push a tag: `git tag companion-v2.1.0 && git push origin companion-v2.1.0` — the workflow publishes the release.
2. Add `"releasesUrl": "https://github.com/nervous-rob/goobster/releases/latest"` to the `screenVision` block in `config.json` — the install page starts offering the downloads.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc807e55-df45-4df1-a0d1-e7da47e865f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc807e55-df45-4df1-a0d1-e7da47e865f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

